### PR TITLE
Character Locations

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,57 @@
+# skillmon
+
+EVE Online skill monitoring/planning desktop app. Tauri v2 (Rust backend) + React 19 frontend.
+
+## Stack
+
+- **Frontend**: React 19, TypeScript, TanStack Router, TanStack Query, Tailwind v4, shadcn/ui, Zustand
+- **Backend**: Rust (Tauri v2), SQLite via sqlx, EVE ESI API
+- **Build**: pnpm, Vite, Cargo
+
+## Commands
+
+```bash
+pnpm tauri:dev       # dev (runs typegen first)
+pnpm tauri:build     # prod build (runs typegen first)
+pnpm typegen         # generate TS types from Rust structs → src/generated/
+pnpm typecheck       # tsc --noEmit
+pnpm test            # vitest (TZ=UTC)
+pnpm lint            # eslint
+pnpm lint:rust       # cargo clippy -D warnings
+pnpm format          # prettier + cargo fmt
+pnpm verify          # typegen + lint:full + format:check:all + typecheck
+```
+
+## Critical Rules
+
+- **Never hand-edit `src/generated/`** — auto-generated from Rust structs. Run `pnpm typegen` after any Rust struct changes.
+- **`routeTree.gen.ts` is generated** — run `pnpm generate-route-tree` or let Vite plugin handle it.
+- Husky + lint-staged enforce eslint/prettier on TS and clippy/fmt on Rust pre-commit.
+
+## Architecture
+
+### Frontend (`src/`)
+
+- `routes/` — TanStack Router file-based routes
+- `components/` — React components; `ui/` = shadcn primitives
+- `hooks/tauri/` — typed wrappers around Tauri commands (TanStack Query)
+- `generated/` — Tauri typegen output, never edit manually
+- `stores/` — Zustand stores
+- `lib/` — shared utilities
+
+### Backend (`src-tauri/src/`)
+
+- `commands/` — Tauri invoke handlers (exposed to frontend)
+- `db/` — sqlx queries per domain (accounts, characters, skill_plans, etc.)
+- `esi/` — EVE ESI HTTP client + rate limiting
+- `auth/` — OAuth2 + callback server
+- `sde/` — Static Data Export import/management
+- `notifications/` — background notification checks
+
+## Patterns
+
+- Tauri commands return `Result<T, String>` (anyhow errors stringified)
+- ESI calls go through rate-limiter in `esi/`
+- DB uses sqlx with SQLite; pool managed via Tauri state
+- Frontend uses TanStack Query for all async data; invalidate on mutations
+- Use `ts-pattern` for exhaustive matching on discriminated unions

--- a/src-tauri/migrations/018_add_station_type_id.sql
+++ b/src-tauri/migrations/018_add_station_type_id.sql
@@ -1,0 +1,1 @@
+ALTER TABLE stations ADD COLUMN type_id INTEGER;

--- a/src-tauri/src/commands/clones.rs
+++ b/src-tauri/src/commands/clones.rs
@@ -48,13 +48,20 @@ async fn resolve_clone_location(
                     format!("Unknown Location {}", location_id)
                 };
 
-                db::upsert_station(pool, location_id, &name, station.system_id, station.owner)
-                    .await?;
+                db::upsert_station(
+                    pool,
+                    location_id,
+                    &name,
+                    station.system_id,
+                    Some(station.type_id),
+                    station.owner,
+                )
+                .await?;
 
                 Ok(name)
             } else {
                 let name = format!("Unknown Location {}", location_id);
-                db::upsert_station(pool, location_id, &name, 0, None).await?;
+                db::upsert_station(pool, location_id, &name, 0, None, None).await?;
                 Ok(name)
             }
         }

--- a/src-tauri/src/commands/location.rs
+++ b/src-tauri/src/commands/location.rs
@@ -4,8 +4,9 @@ use tauri::State;
 
 use crate::auth;
 use crate::db;
-use crate::esi::{self, EsiScope};
+use crate::esi;
 use crate::esi_helpers;
+use crate::features::FeatureId;
 use crate::utils;
 
 #[derive(Debug, Clone, Serialize)]
@@ -30,11 +31,7 @@ pub async fn get_character_location(
     rate_limits: State<'_, esi::RateLimitStore>,
     character_id: i64,
 ) -> Result<CharacterLocation, String> {
-    let required_scopes = [
-        EsiScope::ReadLocationV1,
-        EsiScope::ReadOnlineV1,
-        EsiScope::ReadShipTypeV1,
-    ];
+    let required_scopes = FeatureId::Locations.scopes();
 
     let missing_scopes = auth::check_token_scopes(&pool, character_id, &required_scopes)
         .await
@@ -170,12 +167,6 @@ pub struct CharacterLocationOverview {
     pub implants: Vec<ImplantInfo>,
 }
 
-const LOCATION_SCOPES: [EsiScope; 3] = [
-    EsiScope::ReadLocationV1,
-    EsiScope::ReadOnlineV1,
-    EsiScope::ReadShipTypeV1,
-];
-
 #[tauri::command]
 pub async fn get_all_characters_locations(
     pool: State<'_, db::Pool>,
@@ -194,8 +185,8 @@ pub async fn get_all_characters_locations(
         let character_name = character.character_name.clone();
 
         tasks.push(tokio::spawn(async move {
-            // Check if character has location scopes
-            let missing_scopes = auth::check_token_scopes(&pool, char_id, &LOCATION_SCOPES)
+            let location_scopes = FeatureId::Locations.scopes();
+            let missing_scopes = auth::check_token_scopes(&pool, char_id, &location_scopes)
                 .await
                 .map_err(|e| format!("Auth error for {}: {}", character_name, e))?;
 

--- a/src-tauri/src/commands/location.rs
+++ b/src-tauri/src/commands/location.rs
@@ -1,10 +1,12 @@
+use futures_util::future::join_all;
+use serde::Serialize;
+use tauri::State;
+
 use crate::auth;
 use crate::db;
 use crate::esi::{self, EsiScope};
 use crate::esi_helpers;
 use crate::utils;
-use serde::Serialize;
-use tauri::State;
 
 #[derive(Debug, Clone, Serialize)]
 pub struct CharacterLocation {
@@ -98,6 +100,7 @@ pub async fn get_character_location(
                 station_id,
                 &station_info.name,
                 station_info.system_id,
+                Some(station_info.type_id),
                 station_info.owner,
             )
             .await;
@@ -138,4 +141,273 @@ pub async fn get_character_location(
         last_login: online.last_login.map(|d| d.to_rfc3339()),
         last_logout: online.last_logout.map(|d| d.to_rfc3339()),
     })
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct ImplantInfo {
+    pub type_id: i64,
+    pub name: String,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct CharacterLocationOverview {
+    pub character_id: i64,
+    pub character_name: String,
+    pub has_location_scope: bool,
+    pub is_online: Option<bool>,
+    pub is_docked: Option<bool>,
+    pub solar_system_name: Option<String>,
+    pub region_name: Option<String>,
+    pub station_id: Option<i64>,
+    pub station_name: Option<String>,
+    pub structure_id: Option<i64>,
+    pub structure_name: Option<String>,
+    /// The type_id of the station or structure the character is docked in (for image rendering)
+    pub structure_type_id: Option<i64>,
+    pub ship_type_id: Option<i64>,
+    pub ship_type_name: Option<String>,
+    pub ship_name: Option<String>,
+    pub implants: Vec<ImplantInfo>,
+}
+
+const LOCATION_SCOPES: [EsiScope; 3] = [
+    EsiScope::ReadLocationV1,
+    EsiScope::ReadOnlineV1,
+    EsiScope::ReadShipTypeV1,
+];
+
+#[tauri::command]
+pub async fn get_all_characters_locations(
+    pool: State<'_, db::Pool>,
+    rate_limits: State<'_, esi::RateLimitStore>,
+) -> Result<Vec<CharacterLocationOverview>, String> {
+    let characters = db::get_all_characters(&pool)
+        .await
+        .map_err(|e| format!("Failed to get characters: {}", e))?;
+
+    let mut tasks = Vec::new();
+
+    for character in characters {
+        let pool = pool.inner().clone();
+        let rate_limits = rate_limits.inner().clone();
+        let char_id = character.character_id;
+        let character_name = character.character_name.clone();
+
+        tasks.push(tokio::spawn(async move {
+            // Check if character has location scopes
+            let missing_scopes = auth::check_token_scopes(&pool, char_id, &LOCATION_SCOPES)
+                .await
+                .map_err(|e| format!("Auth error for {}: {}", character_name, e))?;
+
+            if !missing_scopes.is_empty() {
+                return Ok(CharacterLocationOverview {
+                    character_id: char_id,
+                    character_name,
+                    has_location_scope: false,
+                    is_online: None,
+                    is_docked: None,
+                    solar_system_name: None,
+                    region_name: None,
+                    station_id: None,
+                    station_name: None,
+                    structure_id: None,
+                    structure_name: None,
+                    structure_type_id: None,
+                    ship_type_id: None,
+                    ship_type_name: None,
+                    ship_name: None,
+                    implants: vec![],
+                });
+            }
+
+            let access_token = auth::ensure_valid_access_token(&pool, char_id)
+                .await
+                .map_err(|e| format!("Failed to get token for {}: {}", character_name, e))?;
+
+            let client = esi_helpers::create_authenticated_client(&access_token)
+                .map_err(|e| format!("Failed to create client for {}: {}", character_name, e))?;
+
+            // Fetch location, ship, online status, and implants in parallel
+            let (location_res, ship_res, online_res, implants_res) = tokio::join!(
+                esi_helpers::get_cached_character_location(&pool, &client, char_id, &rate_limits),
+                esi_helpers::get_cached_character_ship(&pool, &client, char_id, &rate_limits),
+                esi_helpers::get_cached_character_online(&pool, &client, char_id, &rate_limits),
+                esi_helpers::get_cached_character_implants(&pool, &client, char_id, &rate_limits),
+            );
+
+            let location = location_res
+                .map_err(|e| format!("Failed to fetch location for {}: {}", character_name, e))?
+                .ok_or_else(|| format!("No location data for {}", character_name))?;
+            let ship = ship_res
+                .map_err(|e| format!("Failed to fetch ship for {}: {}", character_name, e))?
+                .ok_or_else(|| format!("No ship data for {}", character_name))?;
+            let online = online_res
+                .map_err(|e| {
+                    format!(
+                        "Failed to fetch online status for {}: {}",
+                        character_name, e
+                    )
+                })?
+                .ok_or_else(|| format!("No online status for {}", character_name))?;
+            let implant_ids = implants_res
+                .map_err(|e| format!("Failed to fetch implants for {}: {}", character_name, e))?
+                .unwrap_or_default();
+
+            // Resolve system → constellation → region
+            let system_info = esi_helpers::get_cached_solar_system_info(
+                &pool,
+                &client,
+                location.solar_system_id,
+                &rate_limits,
+            )
+            .await
+            .map_err(|e| format!("Failed to fetch system info for {}: {}", character_name, e))?
+            .ok_or_else(|| format!("No system info for {}", character_name))?;
+
+            let region_name = if let Ok(Some(constellation)) =
+                esi_helpers::get_cached_constellation_info(
+                    &pool,
+                    &client,
+                    system_info.constellation_id,
+                    &rate_limits,
+                )
+                .await
+            {
+                if let Ok(Some(region)) = esi_helpers::get_cached_region_info(
+                    &pool,
+                    &client,
+                    constellation.region_id,
+                    &rate_limits,
+                )
+                .await
+                {
+                    Some(region.name)
+                } else {
+                    None
+                }
+            } else {
+                None
+            };
+
+            // Resolve ship type name
+            let type_names = utils::get_type_names(&pool, &[ship.ship_type_id]).await?;
+            let ship_type_name = type_names.get(&ship.ship_type_id).cloned();
+
+            // Resolve station or structure name
+            let mut station_name = None;
+            let mut structure_type_id: Option<i64> = None;
+            if let Some(station_id) = location.station_id {
+                if let Ok(Some(station)) = db::get_station(&pool, station_id).await {
+                    station_name = Some(station.name);
+                    structure_type_id = station.type_id;
+                } else if let Ok(Some(station_info)) =
+                    esi_helpers::get_cached_station_info(&pool, &client, station_id, &rate_limits)
+                        .await
+                {
+                    station_name = Some(station_info.name.clone());
+                    structure_type_id = Some(station_info.type_id);
+                    let _ = db::upsert_station(
+                        &pool,
+                        station_id,
+                        &station_info.name,
+                        station_info.system_id,
+                        Some(station_info.type_id),
+                        station_info.owner,
+                    )
+                    .await;
+                }
+            }
+
+            let mut structure_name = None;
+            if let Some(structure_id) = location.structure_id {
+                if let Ok(Some(structure)) = db::get_structure(&pool, structure_id).await {
+                    structure_name = Some(structure.name);
+                    structure_type_id = structure.type_id;
+                } else if let Ok(Some(structure_info)) = esi_helpers::get_cached_structure_info(
+                    &pool,
+                    &client,
+                    structure_id,
+                    &rate_limits,
+                )
+                .await
+                {
+                    structure_name = Some(structure_info.name.clone());
+                    structure_type_id = structure_info.type_id;
+                    let _ = db::upsert_structure(
+                        &pool,
+                        structure_id,
+                        &structure_info.name,
+                        structure_info.solar_system_id,
+                        structure_info.type_id,
+                        structure_info.owner_id,
+                    )
+                    .await;
+                }
+            }
+
+            // Resolve implant names
+            let implant_names = utils::get_type_names(&pool, &implant_ids).await?;
+            let implants = implant_ids
+                .iter()
+                .map(|&type_id| ImplantInfo {
+                    type_id,
+                    name: implant_names
+                        .get(&type_id)
+                        .cloned()
+                        .unwrap_or_else(|| format!("Unknown Implant {}", type_id)),
+                })
+                .collect();
+
+            let is_docked = location.station_id.is_some() || location.structure_id.is_some();
+
+            Ok(CharacterLocationOverview {
+                character_id: char_id,
+                character_name,
+                has_location_scope: true,
+                is_online: Some(online.online),
+                is_docked: Some(is_docked),
+                solar_system_name: Some(system_info.name),
+                region_name,
+                station_id: location.station_id,
+                station_name,
+                structure_id: location.structure_id,
+                structure_name,
+                structure_type_id,
+                ship_type_id: Some(ship.ship_type_id),
+                ship_type_name,
+                ship_name: Some(ship.ship_name),
+                implants,
+            })
+        }));
+    }
+
+    let task_results = join_all(tasks).await;
+    let mut results = Vec::new();
+
+    for task_res in task_results {
+        match task_res {
+            Ok(Ok(overview)) => results.push(overview),
+            Ok(Err(e)) => return Err(e),
+            Err(e) => return Err(format!("Task panicked: {}", e)),
+        }
+    }
+
+    results.sort_by(|a, b| {
+        let group = |c: &CharacterLocationOverview| -> u8 {
+            if !c.has_location_scope {
+                3
+            } else if c.is_online == Some(true) {
+                0
+            } else if c.is_docked == Some(false) {
+                1
+            } else {
+                2
+            }
+        };
+        group(a)
+            .cmp(&group(b))
+            .then_with(|| a.character_name.cmp(&b.character_name))
+    });
+
+    Ok(results)
 }

--- a/src-tauri/src/db/locations.rs
+++ b/src-tauri/src/db/locations.rs
@@ -9,6 +9,7 @@ pub struct Station {
     pub station_id: i64,
     pub name: String,
     pub system_id: i64,
+    pub type_id: Option<i64>,
     pub owner: Option<i64>,
     pub updated_at: i64,
 }
@@ -25,7 +26,7 @@ pub struct Structure {
 
 pub async fn get_station(pool: &Pool, station_id: i64) -> Result<Option<Station>> {
     let station = sqlx::query_as::<_, Station>(
-        "SELECT station_id, name, system_id, owner, updated_at FROM stations WHERE station_id = ?",
+        "SELECT station_id, name, system_id, type_id, owner, updated_at FROM stations WHERE station_id = ?",
     )
     .bind(station_id)
     .fetch_optional(pool)
@@ -50,20 +51,23 @@ pub async fn upsert_station(
     station_id: i64,
     name: &str,
     system_id: i64,
+    type_id: Option<i64>,
     owner: Option<i64>,
 ) -> Result<()> {
     let now = chrono::Utc::now().timestamp();
     sqlx::query(
-        "INSERT INTO stations (station_id, name, system_id, owner, updated_at) VALUES (?, ?, ?, ?, ?)
-         ON CONFLICT(station_id) DO UPDATE SET name = ?, system_id = ?, owner = ?, updated_at = ?",
+        "INSERT INTO stations (station_id, name, system_id, type_id, owner, updated_at) VALUES (?, ?, ?, ?, ?, ?)
+         ON CONFLICT(station_id) DO UPDATE SET name = ?, system_id = ?, type_id = ?, owner = ?, updated_at = ?",
     )
     .bind(station_id)
     .bind(name)
     .bind(system_id)
+    .bind(type_id)
     .bind(owner)
     .bind(now)
     .bind(name)
     .bind(system_id)
+    .bind(type_id)
     .bind(owner)
     .bind(now)
     .execute(pool)

--- a/src-tauri/src/esi_helpers.rs
+++ b/src-tauri/src/esi_helpers.rs
@@ -250,3 +250,25 @@ pub async fn get_cached_structure_info(
     let cache_key = format!("{}:0", endpoint_path);
     esi::fetch_cached(pool, client, &endpoint_path, &cache_key, rate_limits, 0).await
 }
+
+pub async fn get_cached_constellation_info(
+    pool: &db::Pool,
+    client: &reqwest::Client,
+    constellation_id: i64,
+    rate_limits: &esi::RateLimitStore,
+) -> Result<Option<esi::UniverseConstellationsConstellationIdGet>> {
+    let endpoint_path = format!("universe/constellations/{}", constellation_id);
+    let cache_key = format!("{}:0", endpoint_path);
+    esi::fetch_cached(pool, client, &endpoint_path, &cache_key, rate_limits, 0).await
+}
+
+pub async fn get_cached_region_info(
+    pool: &db::Pool,
+    client: &reqwest::Client,
+    region_id: i64,
+    rate_limits: &esi::RateLimitStore,
+) -> Result<Option<esi::UniverseRegionsRegionIdGet>> {
+    let endpoint_path = format!("universe/regions/{}", region_id);
+    let cache_key = format!("{}:0", endpoint_path);
+    esi::fetch_cached(pool, client, &endpoint_path, &cache_key, rate_limits, 0).await
+}

--- a/src-tauri/src/features.rs
+++ b/src-tauri/src/features.rs
@@ -19,6 +19,14 @@ impl FeatureId {
             FeatureId::Waypoints => "waypoints",
         }
     }
+
+    pub fn scopes(self) -> Vec<EsiScope> {
+        get_optional_features()
+            .into_iter()
+            .find(|f| f.id == self)
+            .map(|f| f.scopes)
+            .unwrap_or_default()
+    }
 }
 
 impl std::str::FromStr for FeatureId {

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -279,6 +279,7 @@ pub fn run() {
             commands::auth::start_eve_login,
             is_startup_complete,
             commands::location::get_character_location,
+            commands::location::get_all_characters_locations,
             commands::characters::logout_character,
             commands::accounts::get_accounts_and_characters,
             commands::accounts::create_account,

--- a/src/components/LocationTable.tsx
+++ b/src/components/LocationTable.tsx
@@ -1,0 +1,118 @@
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from '@/components/ui/table';
+import { useAllCharactersLocations } from '@/hooks/tauri/useLocationsOverview';
+
+import { LocationTableRow } from './LocationTableRow';
+import { Card, CardContent, CardHeader, CardTitle } from './ui/card';
+import { Skeleton } from './ui/skeleton';
+
+export function LocationTable() {
+  const { data: characters, isLoading, error } = useAllCharactersLocations();
+
+  if (isLoading) {
+    return (
+      <Card>
+        <CardHeader>
+          <Skeleton className="h-6 w-48" />
+        </CardHeader>
+        <CardContent>
+          <Table>
+            <TableHeader>
+              <TableRow>
+                <TableHead className="w-8 text-center">Status</TableHead>
+                <TableHead>Character</TableHead>
+                <TableHead className="w-10 text-center">Docked</TableHead>
+                <TableHead>Ship</TableHead>
+                <TableHead className="w-10 text-center">Implants</TableHead>
+                <TableHead>Location</TableHead>
+                <TableHead>Structure</TableHead>
+              </TableRow>
+            </TableHeader>
+            <TableBody>
+              {[...Array(6)].map((_, i) => (
+                <TableRow key={i}>
+                  <TableCell className="text-center">
+                    <Skeleton className="h-2 w-2 rounded-full mx-auto" />
+                  </TableCell>
+                  <TableCell>
+                    <Skeleton className="h-8 w-40" />
+                  </TableCell>
+                  <TableCell>
+                    <Skeleton className="h-4 w-4" />
+                  </TableCell>
+                  <TableCell>
+                    <Skeleton className="h-8 w-48" />
+                  </TableCell>
+                  <TableCell>
+                    <Skeleton className="h-4 w-4" />
+                  </TableCell>
+                  <TableCell>
+                    <Skeleton className="h-4 w-40" />
+                  </TableCell>
+                  <TableCell>
+                    <Skeleton className="h-4 w-32" />
+                  </TableCell>
+                </TableRow>
+              ))}
+            </TableBody>
+          </Table>
+        </CardContent>
+      </Card>
+    );
+  }
+
+  if (error) {
+    return (
+      <div className="p-4 text-destructive bg-destructive/10 rounded-md">
+        Error loading locations: {String(error)}
+      </div>
+    );
+  }
+
+  if (!characters || characters.length === 0) {
+    return (
+      <Card>
+        <CardHeader>
+          <CardTitle>Character Locations</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <p className="text-muted-foreground">No characters found.</p>
+        </CardContent>
+      </Card>
+    );
+  }
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>Character Locations ({characters.length})</CardTitle>
+      </CardHeader>
+      <CardContent>
+        <Table>
+          <TableHeader>
+            <TableRow>
+              <TableHead className="w-8 text-center">Status</TableHead>
+              <TableHead>Character</TableHead>
+              <TableHead className="w-10 text-center">Docked</TableHead>
+              <TableHead>Ship</TableHead>
+              <TableHead className="w-10 text-center">Implants</TableHead>
+              <TableHead>Location</TableHead>
+              <TableHead>Structure</TableHead>
+            </TableRow>
+          </TableHeader>
+          <TableBody>
+            {characters.map((char) => (
+              <LocationTableRow key={char.character_id} character={char} />
+            ))}
+          </TableBody>
+        </Table>
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/components/LocationTable.tsx
+++ b/src/components/LocationTable.tsx
@@ -70,7 +70,8 @@ export function LocationTable() {
   if (error) {
     return (
       <div className="p-4 text-destructive bg-destructive/10 rounded-md">
-        Error loading locations: {String(error)}
+        Error loading locations:{' '}
+        {error instanceof Error ? error.message : String(error)}
       </div>
     );
   }

--- a/src/components/LocationTableRow.tsx
+++ b/src/components/LocationTableRow.tsx
@@ -1,0 +1,210 @@
+import { Link } from '@tanstack/react-router';
+import { MapPinHouse, Rocket, UserPlus } from 'lucide-react';
+import type React from 'react';
+import { match } from 'ts-pattern';
+
+import { TableCell, TableRow } from '@/components/ui/table';
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from '@/components/ui/tooltip';
+import type { CharacterLocationOverview } from '@/generated/types';
+import { cn } from '@/lib/utils';
+
+interface LocationCellProps {
+  system: string | null | undefined;
+  region: string | null | undefined;
+}
+
+function LocationCell({ system, region }: LocationCellProps) {
+  if (system && region) {
+    return (
+      <a
+        href={`https://evemaps.dotlan.net/map/${region.replace(/ /g, '_')}/${system.replace(/ /g, '_')}`}
+        target="_blank"
+        rel="noreferrer"
+        className="hover:border-b hover:border-dotted hover:border-current"
+      >
+        {system}
+        <span className="text-muted-foreground ml-1">· {region}</span>
+      </a>
+    );
+  }
+  if (system) {
+    return <span>{system}</span>;
+  }
+  return <span className="text-muted-foreground">—</span>;
+}
+
+interface LocationTableRowProps {
+  character: CharacterLocationOverview;
+}
+
+export function LocationTableRow({ character }: LocationTableRowProps) {
+  if (!character.has_location_scope) {
+    return (
+      <TableRow>
+        <TableCell className="text-center opacity-50">
+          <span>—</span>
+        </TableCell>
+        <TableCell className="font-medium opacity-50">
+          <Link
+            to="/characters/$characterId"
+            params={{ characterId: character.character_id.toString() }}
+            className="flex items-center gap-3 hover:underline"
+          >
+            <img
+              src={`https://images.evetech.net/characters/${character.character_id}/portrait?size=32`}
+              alt={character.character_name}
+              className="h-8 w-8 rounded object-contain shrink-0"
+              width={32}
+              height={32}
+              loading="lazy"
+            />
+            <span>{character.character_name}</span>
+          </Link>
+        </TableCell>
+        <TableCell colSpan={5}>
+          <span className="text-muted-foreground text-sm">
+            Missing location scopes. Re-authenticate this character to grant
+            location access.
+          </span>
+        </TableCell>
+      </TableRow>
+    );
+  }
+
+  const isOnline = character.is_online ?? false;
+  const isDocked = character.is_docked ?? false;
+
+  const { dockedIcon, dockedLabel } = match({ isDocked, isOnline })
+    .with({ isDocked: true }, () => ({
+      dockedIcon: (
+        <MapPinHouse className="h-4 w-4 text-muted-foreground" />
+      ) as React.ReactNode,
+      dockedLabel: 'Docked',
+    }))
+    .with({ isOnline: true }, () => ({
+      dockedIcon: (
+        <Rocket className="h-4 w-4 text-muted-foreground" />
+      ) as React.ReactNode,
+      dockedLabel: 'Undocked',
+    }))
+    .otherwise(() => ({
+      dockedIcon: (
+        <Rocket className="h-4 w-4 text-yellow-500" />
+      ) as React.ReactNode,
+      dockedLabel: 'Undocked (offline)',
+    }));
+
+  const hasImplants = character.implants.length > 0;
+
+  return (
+    <TableRow>
+      <TableCell className="text-center">
+        <div
+          className={cn(
+            'h-2 w-2 rounded-full mx-auto',
+            isOnline
+              ? 'bg-green-500 shadow-[0_0_8px_rgba(34,197,94,0.5)]'
+              : 'bg-gray-400'
+          )}
+        />
+      </TableCell>
+      <TableCell className="font-medium">
+        <Link
+          to="/characters/$characterId"
+          params={{ characterId: character.character_id.toString() }}
+          className="flex items-center gap-3 hover:underline"
+        >
+          <img
+            src={`https://images.evetech.net/characters/${character.character_id}/portrait?size=32`}
+            alt={character.character_name}
+            className="h-8 w-8 rounded object-contain shrink-0"
+            width={32}
+            height={32}
+            loading="lazy"
+          />
+          <span>{character.character_name}</span>
+        </Link>
+      </TableCell>
+      <TableCell className="text-center">
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <span className="inline-flex justify-center">{dockedIcon}</span>
+          </TooltipTrigger>
+          <TooltipContent>{dockedLabel}</TooltipContent>
+        </Tooltip>
+      </TableCell>
+      <TableCell>
+        {character.ship_type_id && character.ship_name ? (
+          <div className="flex items-center gap-2">
+            <img
+              src={`https://images.evetech.net/types/${character.ship_type_id}/render?size=32`}
+              alt={character.ship_type_name ?? ''}
+              className="h-8 w-8 rounded object-contain"
+            />
+            <span>
+              {character.ship_name}
+              {character.ship_type_name && (
+                <span className="text-muted-foreground ml-1">
+                  · {character.ship_type_name}
+                </span>
+              )}
+            </span>
+          </div>
+        ) : (
+          <span className="text-muted-foreground">—</span>
+        )}
+      </TableCell>
+      <TableCell className="text-center">
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <span className="inline-flex justify-center">
+              <UserPlus
+                className={cn(
+                  'h-4 w-4',
+                  hasImplants ? 'text-primary' : 'text-muted-foreground/50'
+                )}
+              />
+            </span>
+          </TooltipTrigger>
+          <TooltipContent>
+            {hasImplants ? (
+              <ul className="space-y-0.5">
+                {character.implants.map((implant) => (
+                  <li key={implant.type_id}>{implant.name}</li>
+                ))}
+              </ul>
+            ) : (
+              <span>No implants</span>
+            )}
+          </TooltipContent>
+        </Tooltip>
+      </TableCell>
+      <TableCell>
+        <LocationCell
+          system={character.solar_system_name}
+          region={character.region_name}
+        />
+      </TableCell>
+      <TableCell>
+        {(character.station_name ?? character.structure_name) ? (
+          <div className="flex items-center gap-2">
+            {character.structure_type_id && (
+              <img
+                src={`https://images.evetech.net/types/${character.structure_type_id}/render?size=32`}
+                alt=""
+                className="h-8 w-8 rounded object-contain"
+              />
+            )}
+            <span>{character.station_name ?? character.structure_name}</span>
+          </div>
+        ) : (
+          <span className="text-muted-foreground">—</span>
+        )}
+      </TableCell>
+    </TableRow>
+  );
+}

--- a/src/components/ui/tooltip.tsx
+++ b/src/components/ui/tooltip.tsx
@@ -44,13 +44,13 @@ function TooltipContent({
         data-slot="tooltip-content"
         sideOffset={sideOffset}
         className={cn(
-          "bg-foreground text-background animate-in fade-in-0 zoom-in-95 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-50 w-fit origin-(--radix-tooltip-content-transform-origin) rounded-md px-3 py-1.5 text-xs text-balance",
+          "bg-popover text-popover-foreground border border-border animate-in fade-in-0 zoom-in-95 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-50 w-fit origin-(--radix-tooltip-content-transform-origin) rounded-md px-3 py-1.5 text-xs text-balance",
           className
         )}
         {...props}
       >
         {children}
-        <TooltipPrimitive.Arrow className="bg-foreground fill-foreground z-50 size-2.5 translate-y-[calc(-50%_-_2px)] rotate-45 rounded-[2px]" />
+        <TooltipPrimitive.Arrow className="bg-popover fill-popover border-border z-50 size-2.5 translate-y-[calc(-50%_-_2px)] rotate-45 rounded-[2px]" />
       </TooltipPrimitive.Content>
     </TooltipPrimitive.Portal>
   )

--- a/src/hooks/tauri/queryKeys.ts
+++ b/src/hooks/tauri/queryKeys.ts
@@ -94,4 +94,5 @@ export const queryKeys = {
     ['character-feature-scope-status'] as const,
 
   location: (characterId: number) => ['location', characterId] as const,
+  locationsOverview: () => ['locationsOverview'] as const,
 };

--- a/src/hooks/tauri/useLocationsOverview.ts
+++ b/src/hooks/tauri/useLocationsOverview.ts
@@ -1,0 +1,14 @@
+import { useQuery } from '@tanstack/react-query';
+
+import { getAllCharactersLocations } from '@/generated/commands';
+import type { CharacterLocationOverview } from '@/generated/types';
+
+import { queryKeys } from './queryKeys';
+
+export function useAllCharactersLocations() {
+  return useQuery<CharacterLocationOverview[]>({
+    queryKey: queryKeys.locationsOverview(),
+    queryFn: () => getAllCharactersLocations(),
+    refetchInterval: 60_000,
+  });
+}

--- a/src/hooks/tauri/useLocationsOverview.ts
+++ b/src/hooks/tauri/useLocationsOverview.ts
@@ -10,5 +10,6 @@ export function useAllCharactersLocations() {
     queryKey: queryKeys.locationsOverview(),
     queryFn: () => getAllCharactersLocations(),
     refetchInterval: 60_000,
+    staleTime: 55_000,
   });
 }

--- a/src/routes/__root.tsx
+++ b/src/routes/__root.tsx
@@ -13,6 +13,7 @@ import { NavigationTabs } from '@/components/ui/navigation-tabs';
 import { Toaster } from '@/components/ui/sonner';
 import { Spinner } from '@/components/ui/spinner';
 import { useAuthEvents } from '@/hooks/tauri/useAuthEvents';
+import { useEnabledFeatures } from '@/hooks/tauri/useSettings';
 import { useStartupState } from '@/hooks/tauri/useStartupState';
 import { cn } from '@/lib/utils';
 import { useSkillDetailStore } from '@/stores/skillDetailStore';
@@ -27,6 +28,8 @@ function RootComponent() {
   const { open, skillId, characterId, closeSkillDetail } =
     useSkillDetailStore();
   const { updateAvailable, setUpdate } = useUpdateStore();
+  const { data: enabledFeatures } = useEnabledFeatures();
+  const locationsEnabled = enabledFeatures?.includes('Locations') ?? false;
 
   useEffect(() => {
     const checkForUpdates = async () => {
@@ -63,6 +66,9 @@ function RootComponent() {
           items={[
             { to: '/overview', label: 'Overview' },
             { to: '/characters', label: 'Characters' },
+            ...(locationsEnabled
+              ? [{ to: '/location' as const, label: 'Location' }]
+              : []),
             { to: '/plans', label: 'Plans' },
             { to: '/settings', label: 'Settings' },
             { to: '/about', label: 'About' },

--- a/src/routes/location.tsx
+++ b/src/routes/location.tsx
@@ -1,0 +1,18 @@
+import { createFileRoute } from '@tanstack/react-router';
+
+import { LocationTable } from '@/components/LocationTable';
+import { ScrollArea } from '@/components/ui/scroll-area';
+
+function LocationPage() {
+  return (
+    <ScrollArea className="h-full">
+      <div className="container mx-auto p-4">
+        <LocationTable />
+      </div>
+    </ScrollArea>
+  );
+}
+
+export const Route = createFileRoute('/location')({
+  component: LocationPage,
+});


### PR DESCRIPTION
- Adds get_all_characters_locations Tauri command — fetches location, ship, online status, and implants for all characters in parallel (concurrent per-character, parallel
ESI calls within each)
- Adds /location route with a LocationTable overview showing: online status, docked state, ship (with icon), implant count, solar system, region, and station/structure (with
type image)
- Gracefully handles characters missing location ESI scopes — shows them in table with reduced info
- Adds station_type_id to location DB schema (migration 018) for station image rendering