### PR TITLE
Add turborepo

### DIFF
--- a/.claude/hooks/format-on-edit.sh
+++ b/.claude/hooks/format-on-edit.sh
@@ -1,7 +1,6 @@
 #!/bin/bash
-FILE=$(python3 -c "import sys,json; d=json.load(sys.stdin); print(d.get('tool_input', {}).get('file_path', ''))" 2>/dev/null)
+FILE=$(jq -r '.tool_input.file_path // empty' 2>/dev/null)
 [[ -z "$FILE" ]] && exit 0
-touch .claude/.dirty
 if [[ "$FILE" == *.ts || "$FILE" == *.tsx || "$FILE" == *.js ]]; then
   pnpm prettier --write "$FILE" 2>/dev/null || true
   pnpm eslint --fix "$FILE" 2>/dev/null || true

--- a/.claude/hooks/lint-and-typecheck.sh
+++ b/.claude/hooks/lint-and-typecheck.sh
@@ -1,7 +1,4 @@
 #!/bin/bash
-[[ ! -f .claude/.dirty ]] && exit 0
-rm -f .claude/.dirty
-
 run_check() {
     output=$("$@" 2>&1)
     local exit_code=$?
@@ -11,6 +8,4 @@ run_check() {
     fi
 }
 
-run_check pnpm lint
-run_check pnpm lint:rust
-run_check pnpm typecheck
+run_check pnpm turbo run lint lint:rust typecheck

--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,7 @@ dist-ssr
 *.sln
 *.sw?
 .specstory/
+.turbo/
 
 # Generated ESI code
 src-tauri/src/esi/client.rs

--- a/.prettierignore
+++ b/.prettierignore
@@ -13,6 +13,8 @@ src-tauri/target
 src/components/ui/**
 src-tauri/gen/schemas/**
 # Build artifacts
+.turbo/**
+turbo.json
 *.log
 pnpm-lock.yaml
 

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "license": "MIT",
   "author": "snipereagle1 <me@snipereagle.xyz>",
   "type": "module",
+  "packageManager": "pnpm@10.24.0",
   "scripts": {
     "dev": "vite",
     "typecheck": "tsc --noEmit",
@@ -27,7 +28,7 @@
     "format:check:rust": "cd src-tauri && cargo fmt -- --check",
     "lint:full": "pnpm lint && pnpm lint:rust",
     "format:check:all": "pnpm format:check && pnpm format:check:rust",
-    "verify": "pnpm typegen && pnpm lint:full && pnpm format:check:all && pnpm typecheck",
+    "verify": "pnpm typegen && turbo run lint lint:rust typecheck format:check format:check:rust",
     "prepare": "husky"
   },
   "lint-staged": {
@@ -112,6 +113,7 @@
     "prettier": "^3.8.1",
     "shadcn": "^3.7.0",
     "tailwindcss": "^4.1.18",
+    "turbo": "^2.9.12",
     "tw-animate-css": "^1.4.0",
     "typescript": "~5.9.3",
     "typescript-eslint": "^8.53.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -207,6 +207,9 @@ importers:
       tailwindcss:
         specifier: ^4.1.18
         version: 4.1.18
+      turbo:
+        specifier: ^2.9.12
+        version: 2.9.12
       tw-animate-css:
         specifier: ^1.4.0
         version: 1.4.0
@@ -1708,6 +1711,36 @@ packages:
 
   '@ts-morph/common@0.27.0':
     resolution: {integrity: sha512-Wf29UqxWDpc+i61k3oIOzcUfQt79PIT9y/MWfAGlrkjg6lBC1hwDECLXPVJAhWjiGbfBCxZd65F/LIZF3+jeJQ==}
+
+  '@turbo/darwin-64@2.9.12':
+    resolution: {integrity: sha512-eu3eFRmE9NjgZ0wPdRJ44l+LGSeIky+tz5ZQd8zQkw/Yqi+BM7wq+8nbabeoiVUcICi/IZweMOKl/MCmkrd1+g==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@turbo/darwin-arm64@2.9.12':
+    resolution: {integrity: sha512-RUkAE404z/J8NsyrUosMcBaXT6M4bRFxTQrmkDQBLQVXaC8Jl0e9bMvYDSX0GW7Ffm2m3j9y7RXgR1foeUAM9w==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@turbo/linux-64@2.9.12':
+    resolution: {integrity: sha512-InIUtH7cw/vqXNX1Gr7QgWfmw3ct08pV5CpfdEOR48z2u2rzdmpIuk00B/Q2xCb0PMWtKgiMQynfuphmEuUyTQ==}
+    cpu: [x64]
+    os: [linux]
+
+  '@turbo/linux-arm64@2.9.12':
+    resolution: {integrity: sha512-lC6nD//Xh67fmJM0LKaLsg74Wry0aYrgMklpiNgCbUaMdPIOqj0A00iri3NU7Lb7pZHx8ViisgpeDKlpSgFUCA==}
+    cpu: [arm64]
+    os: [linux]
+
+  '@turbo/windows-64@2.9.12':
+    resolution: {integrity: sha512-conYri8VUl72JOdYnLDPYwzqbPcY5ECoHmo9FWoKznemhaAIilj4maHqs9Uar0aKfNoZIULniy+6iWaLtLO34A==}
+    cpu: [x64]
+    os: [win32]
+
+  '@turbo/windows-arm64@2.9.12':
+    resolution: {integrity: sha512-XoR4bsg62/L/esRVcmoMESEiNZ36+YmyjYGLpoqk8nwMgXzzVjNOgX0lRSz5w/U/ajLGv3nhMsS0Q2QOdvp2AQ==}
+    cpu: [arm64]
+    os: [win32]
 
   '@tybys/wasm-util@0.10.1':
     resolution: {integrity: sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg==}
@@ -3986,6 +4019,10 @@ packages:
     engines: {node: '>=18.0.0'}
     hasBin: true
 
+  turbo@2.9.12:
+    resolution: {integrity: sha512-lCPgus1NuTiBdaITWqzSH/Ff6HVL8HHGBtOXHg1dHRfcshN79XkygSdh0M6g8b0td91ILLG5MTkLOkp5UvyPJw==}
+    hasBin: true
+
   tw-animate-css@1.4.0:
     resolution: {integrity: sha512-7bziOlRqH0hJx80h/3mbicLW7o8qLsH5+RaLR2t+OHM3D0JlWGODQKQ4cxbK7WlvmUxpcj6Kgu6EKqjrGFe3QQ==}
 
@@ -5793,6 +5830,24 @@ snapshots:
       fast-glob: 3.3.3
       minimatch: 10.1.1
       path-browserify: 1.0.1
+
+  '@turbo/darwin-64@2.9.12':
+    optional: true
+
+  '@turbo/darwin-arm64@2.9.12':
+    optional: true
+
+  '@turbo/linux-64@2.9.12':
+    optional: true
+
+  '@turbo/linux-arm64@2.9.12':
+    optional: true
+
+  '@turbo/windows-64@2.9.12':
+    optional: true
+
+  '@turbo/windows-arm64@2.9.12':
+    optional: true
 
   '@tybys/wasm-util@0.10.1':
     dependencies:
@@ -8296,6 +8351,15 @@ snapshots:
       get-tsconfig: 4.13.0
     optionalDependencies:
       fsevents: 2.3.3
+
+  turbo@2.9.12:
+    optionalDependencies:
+      '@turbo/darwin-64': 2.9.12
+      '@turbo/darwin-arm64': 2.9.12
+      '@turbo/linux-64': 2.9.12
+      '@turbo/linux-arm64': 2.9.12
+      '@turbo/windows-64': 2.9.12
+      '@turbo/windows-arm64': 2.9.12
 
   tw-animate-css@1.4.0: {}
 

--- a/turbo.json
+++ b/turbo.json
@@ -1,0 +1,45 @@
+{
+  "$schema": "https://turbo.build/schema.json",
+  "tasks": {
+    "lint": {
+      "inputs": [
+        "src/**/*.ts",
+        "src/**/*.tsx",
+        "src/**/*.js",
+        "eslint.config.mjs",
+        ".prettierrc"
+      ]
+    },
+    "lint:rust": {
+      "inputs": [
+        "src-tauri/src/**/*.rs",
+        "src-tauri/Cargo.toml",
+        "src-tauri/Cargo.lock",
+        ".clippy.toml",
+        "rustfmt.toml"
+      ]
+    },
+    "typecheck": {
+      "inputs": [
+        "src/**/*.ts",
+        "src/**/*.tsx",
+        "tsconfig.json",
+        "src/generated/**"
+      ]
+    },
+    "format:check": {
+      "inputs": [
+        "src/**/*.{ts,tsx,js,jsx}",
+        "**/*.md",
+        ".prettierrc",
+        ".prettierignore"
+      ]
+    },
+    "format:check:rust": {
+      "inputs": [
+        "src-tauri/src/**/*.rs",
+        "rustfmt.toml"
+      ]
+    }
+  }
+}


### PR DESCRIPTION
build(turbo): add Turborepo task caching for lint, typecheck, and format checks

Replaces the .dirty flag mechanism with Turbo's file-hash cache. Each task now has precise inputs so only the affected language's checks re-run on change (e.g. editing .rs skips lint + typecheck). Stop hook and verify script both benefit; cache hit drops to ~55ms.

- add turbo.json with lint, lint:rust, typecheck, format:check, format:check:rust tasks and narrow per-language inputs
- update verify to single turbo run covering all check tasks
- replace dirty-flag logic in hooks with pnpm turbo run
- swap python3 JSON parse in format-on-edit.sh for jq
- exclude .turbo/ and turbo.json from Prettier and git