### PR TITLE
Plan Updates

### DIFF
--- a/src-tauri/src/commands/skill_plans.rs
+++ b/src-tauri/src/commands/skill_plans.rs
@@ -1744,17 +1744,25 @@ pub async fn compare_skill_plan_with_character(
         let skill_attr = skill_attributes.get(&entry.skill_type_id);
         let rank = skill_attr.and_then(|attr| attr.rank);
 
-        let skillpoints_for_planned_level = if let Some(rank_val) = rank {
-            utils::calculate_sp_for_level(rank_val, entry.planned_level as i32)
-        } else {
-            0
-        };
+        let (skillpoints_for_planned_level, current_skillpoints_for_level) = rank
+            .map(|rank_val| {
+                let sp_for_level =
+                    utils::calculate_sp_for_level(rank_val, entry.planned_level as i32)
+                        - utils::calculate_sp_for_level(rank_val, (entry.planned_level - 1) as i32);
+                let trained =
+                    trained_sp_for_level(entry.planned_level, current_skillpoints, rank_val);
+                (sp_for_level, trained)
+            })
+            .unwrap_or((0, 0));
 
-        let missing_skillpoints = if trained_level >= entry.planned_level {
-            0
-        } else {
-            (skillpoints_for_planned_level - current_skillpoints).max(0)
-        };
+        let missing_skillpoints = rank.map_or(0, |rank_val| {
+            missing_sp_for_level(
+                entry.planned_level,
+                trained_level,
+                current_skillpoints,
+                rank_val,
+            )
+        });
 
         let status = if trained_level >= entry.planned_level {
             "complete"
@@ -1775,7 +1783,7 @@ pub async fn compare_skill_plan_with_character(
             sort_order: entry.sort_order,
             rank,
             skillpoints_for_planned_level,
-            current_skillpoints,
+            current_skillpoints: current_skillpoints_for_level,
             missing_skillpoints,
             status: status.to_string(),
         });
@@ -1859,7 +1867,12 @@ pub async fn compare_skill_plan_with_all_characters(
                     completed_sp += sp_for_planned;
                 } else {
                     completed_sp += current_skillpoints;
-                    let missing = (sp_for_planned - current_skillpoints).max(0);
+                    let missing = missing_sp_for_level(
+                        entry.planned_level,
+                        trained_level,
+                        current_skillpoints,
+                        rank_val,
+                    );
                     missing_sp += missing;
 
                     if let Some(attr) = attributes.as_ref() {
@@ -1946,4 +1959,111 @@ pub async fn compare_skill_plan_with_all_characters(
         plan: SkillPlanResponse::from(plan),
         comparisons,
     })
+}
+
+fn trained_sp_for_level(planned_level: i64, current_skillpoints: i64, rank: i64) -> i64 {
+    let total = utils::calculate_sp_for_level(rank, planned_level as i32);
+    let previous = utils::calculate_sp_for_level(rank, (planned_level - 1) as i32);
+    (current_skillpoints - previous).clamp(0, total - previous)
+}
+
+fn missing_sp_for_level(
+    planned_level: i64,
+    trained_level: i64,
+    current_skillpoints: i64,
+    rank: i64,
+) -> i64 {
+    if trained_level >= planned_level {
+        return 0;
+    }
+    let sp_for_planned = utils::calculate_sp_for_level(rank, planned_level as i32);
+    let sp_for_previous = utils::calculate_sp_for_level(rank, (planned_level - 1) as i32);
+    let base = current_skillpoints.max(sp_for_previous);
+    (sp_for_planned - base).max(0)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn missing_sp_scoped_to_single_level() {
+        let rank = 1;
+        let sp_1 = utils::calculate_sp_for_level(rank, 1);
+        let sp_2 = utils::calculate_sp_for_level(rank, 2);
+        let sp_3 = utils::calculate_sp_for_level(rank, 3);
+
+        // Untrained character: each level only counts its own slice
+        let missing_1 = missing_sp_for_level(1, 0, 0, rank);
+        let missing_2 = missing_sp_for_level(2, 0, 0, rank);
+        let missing_3 = missing_sp_for_level(3, 0, 0, rank);
+
+        assert_eq!(missing_1, sp_1);
+        assert_eq!(missing_2, sp_2 - sp_1);
+        assert_eq!(missing_3, sp_3 - sp_2);
+
+        // Sum of per-level missing equals total SP for level 3
+        assert_eq!(missing_1 + missing_2 + missing_3, sp_3);
+    }
+
+    #[test]
+    fn missing_sp_zero_when_trained() {
+        let rank = 3;
+        assert_eq!(missing_sp_for_level(2, 2, 10000, rank), 0);
+        assert_eq!(missing_sp_for_level(2, 5, 100000, rank), 0);
+    }
+
+    #[test]
+    fn missing_sp_partial_progress_within_level() {
+        let rank = 1;
+        let sp_2 = utils::calculate_sp_for_level(rank, 2);
+        let sp_3 = utils::calculate_sp_for_level(rank, 3);
+        // Trained to level 2, halfway through level 3
+        let partial_sp = sp_2 + (sp_3 - sp_2) / 2;
+
+        let missing = missing_sp_for_level(3, 2, partial_sp, rank);
+        assert_eq!(missing, sp_3 - partial_sp);
+    }
+
+    #[test]
+    fn trained_sp_scoped_to_level() {
+        let rank = 1;
+        let sp_1 = utils::calculate_sp_for_level(rank, 1);
+        let sp_2 = utils::calculate_sp_for_level(rank, 2);
+        let sp_3 = utils::calculate_sp_for_level(rank, 3);
+
+        // Untrained: 0 trained SP in every level
+        assert_eq!(trained_sp_for_level(1, 0, rank), 0);
+        assert_eq!(trained_sp_for_level(2, 0, rank), 0);
+        assert_eq!(trained_sp_for_level(3, 0, rank), 0);
+
+        // Fully trained to level 2: level 1 and 2 are full, level 3 is 0
+        assert_eq!(trained_sp_for_level(1, sp_2, rank), sp_1);
+        assert_eq!(trained_sp_for_level(2, sp_2, rank), sp_2 - sp_1);
+        assert_eq!(trained_sp_for_level(3, sp_2, rank), 0);
+
+        // Partial progress into level 3
+        let partial = sp_2 + 100;
+        assert_eq!(trained_sp_for_level(1, partial, rank), sp_1);
+        assert_eq!(trained_sp_for_level(2, partial, rank), sp_2 - sp_1);
+        assert_eq!(trained_sp_for_level(3, partial, rank), 100);
+
+        // Fully trained to level 3: all levels capped at their slice
+        assert_eq!(trained_sp_for_level(1, sp_3, rank), sp_1);
+        assert_eq!(trained_sp_for_level(2, sp_3, rank), sp_2 - sp_1);
+        assert_eq!(trained_sp_for_level(3, sp_3, rank), sp_3 - sp_2);
+    }
+
+    #[test]
+    fn missing_sp_no_double_count_across_levels() {
+        let rank = 5;
+        let sp_5 = utils::calculate_sp_for_level(rank, 5);
+
+        // Simulate a plan with levels 1-5 for an untrained character
+        let total_missing: i64 = (1..=5)
+            .map(|level| missing_sp_for_level(level, 0, 0, rank))
+            .sum();
+
+        assert_eq!(total_missing, sp_5);
+    }
 }

--- a/src-tauri/src/commands/skill_plans.rs
+++ b/src-tauri/src/commands/skill_plans.rs
@@ -1863,10 +1863,14 @@ pub async fn compare_skill_plan_with_all_characters(
                 let sp_for_planned =
                     utils::calculate_sp_for_level(rank_val, entry.planned_level as i32);
 
+                let sp_for_previous =
+                    utils::calculate_sp_for_level(rank_val, (entry.planned_level - 1) as i32);
+
                 if trained_level >= entry.planned_level {
-                    completed_sp += sp_for_planned;
+                    completed_sp += sp_for_planned - sp_for_previous;
                 } else {
-                    completed_sp += current_skillpoints;
+                    completed_sp +=
+                        trained_sp_for_level(entry.planned_level, current_skillpoints, rank_val);
                     let missing = missing_sp_for_level(
                         entry.planned_level,
                         trained_level,
@@ -2052,6 +2056,27 @@ mod tests {
         assert_eq!(trained_sp_for_level(1, sp_3, rank), sp_1);
         assert_eq!(trained_sp_for_level(2, sp_3, rank), sp_2 - sp_1);
         assert_eq!(trained_sp_for_level(3, sp_3, rank), sp_3 - sp_2);
+    }
+
+    #[test]
+    fn missing_sp_level_one_with_partial_progress() {
+        let rank = 1;
+        let sp_1 = utils::calculate_sp_for_level(rank, 1);
+        let partial = sp_1 / 2;
+
+        let missing = missing_sp_for_level(1, 0, partial, rank);
+        assert_eq!(missing, sp_1 - partial);
+    }
+
+    #[test]
+    fn trained_sp_high_rank_all_levels() {
+        let rank = 16;
+        let sp_4 = utils::calculate_sp_for_level(rank, 4);
+        let sp_5 = utils::calculate_sp_for_level(rank, 5);
+
+        assert_eq!(trained_sp_for_level(5, sp_5, rank), sp_5 - sp_4);
+        assert_eq!(trained_sp_for_level(5, sp_5 + 1000, rank), sp_5 - sp_4);
+        assert_eq!(trained_sp_for_level(5, sp_4, rank), 0);
     }
 
     #[test]

--- a/src/components/CharacterPlanComparison.tsx
+++ b/src/components/CharacterPlanComparison.tsx
@@ -113,17 +113,20 @@ export function CharacterPlanComparison({
         },
       };
     }
-    const sorted = [...comparison.entries]
+    const allEntries = comparison.entries;
+    const sorted = [...allEntries]
       .filter((e) => !showUntrainedOnly || e.status !== 'complete')
       .sort((a, b) => a.sort_order - b.sort_order);
     return {
       sortedEntries: sorted,
       stats: {
-        total: sorted.length,
-        complete: sorted.filter((e) => e.status === 'complete').length,
-        in_progress: sorted.filter((e) => e.status === 'in_progress').length,
-        not_started: sorted.filter((e) => e.status === 'not_started').length,
-        totalMissingSP: sorted.reduce(
+        total: allEntries.length,
+        complete: allEntries.filter((e) => e.status === 'complete').length,
+        in_progress: allEntries.filter((e) => e.status === 'in_progress')
+          .length,
+        not_started: allEntries.filter((e) => e.status === 'not_started')
+          .length,
+        totalMissingSP: allEntries.reduce(
           (sum, e) => sum + e.missing_skillpoints,
           0
         ),

--- a/src/components/SkillPlans/PlanComparisonTab.tsx
+++ b/src/components/SkillPlans/PlanComparisonTab.tsx
@@ -11,6 +11,7 @@ import {
   DropdownMenuContent,
   DropdownMenuGroup,
   DropdownMenuItem,
+  DropdownMenuLabel,
   DropdownMenuSeparator,
   DropdownMenuTrigger,
 } from '@/components/ui/dropdown-menu';
@@ -23,6 +24,7 @@ import {
   TableHeader,
   TableRow,
 } from '@/components/ui/table';
+import { useAccountsAndCharacters } from '@/hooks/tauri/useAccountsAndCharacters';
 import {
   useExcludedComparisonCharacters,
   usePersistExcludedComparisonCharacters,
@@ -36,6 +38,7 @@ interface PlanComparisonTabProps {
 
 export function PlanComparisonTab({ planId }: PlanComparisonTabProps) {
   const { data, isLoading, error } = usePlanComparisonAll(planId);
+  const { data: accountsData } = useAccountsAndCharacters();
   const navigate = useNavigate();
   const { data: persistedExcluded } = useExcludedComparisonCharacters();
   const persistExcluded = usePersistExcludedComparisonCharacters();
@@ -43,6 +46,17 @@ export function PlanComparisonTab({ planId }: PlanComparisonTabProps) {
     () => new Set(persistedExcluded ?? []),
     [persistedExcluded]
   );
+
+  const characterAccountMap = useMemo(() => {
+    const map = new Map<number, string>();
+    if (!accountsData) return map;
+    for (const account of accountsData.accounts) {
+      for (const char of account.characters) {
+        map.set(char.character_id, account.name);
+      }
+    }
+    return map;
+  }, [accountsData]);
 
   const filteredComparisons = useMemo(() => {
     const comparisons = data?.comparisons ?? [];
@@ -74,6 +88,32 @@ export function PlanComparisonTab({ planId }: PlanComparisonTabProps) {
     if (!data) return;
     persistExcluded(data.comparisons.map((c) => c.character_id));
   };
+
+  const groupedComparisons = useMemo(() => {
+    if (!data || !accountsData) return [];
+    const comparisonMap = new Map(
+      data.comparisons.map((c) => [c.character_id, c])
+    );
+    const groups: { label: string; characters: typeof data.comparisons }[] = [];
+
+    for (const account of accountsData.accounts) {
+      const chars = account.characters
+        .map((c) => comparisonMap.get(c.character_id))
+        .filter(Boolean) as typeof data.comparisons;
+      if (chars.length > 0) {
+        groups.push({ label: account.name, characters: chars });
+      }
+    }
+
+    const unassignedChars = accountsData.unassigned_characters
+      .map((c) => comparisonMap.get(c.character_id))
+      .filter(Boolean) as typeof data.comparisons;
+    if (unassignedChars.length > 0) {
+      groups.push({ label: 'Unassigned', characters: unassignedChars });
+    }
+
+    return groups;
+  }, [data, accountsData]);
 
   if (isLoading) {
     return (
@@ -130,18 +170,22 @@ export function PlanComparisonTab({ planId }: PlanComparisonTabProps) {
               Select None
             </DropdownMenuItem>
             <DropdownMenuSeparator />
-            <DropdownMenuGroup>
-              {data.comparisons.map((c) => (
-                <DropdownMenuCheckboxItem
-                  key={c.character_id}
-                  checked={!excludedCharacterIds.has(c.character_id)}
-                  onCheckedChange={() => toggleCharacter(c.character_id)}
-                  onSelect={(e) => e.preventDefault()}
-                >
-                  {c.character_name}
-                </DropdownMenuCheckboxItem>
-              ))}
-            </DropdownMenuGroup>
+            {groupedComparisons.map((group, i) => (
+              <DropdownMenuGroup key={group.label}>
+                {i > 0 && <DropdownMenuSeparator />}
+                <DropdownMenuLabel>{group.label}</DropdownMenuLabel>
+                {group.characters.map((c) => (
+                  <DropdownMenuCheckboxItem
+                    key={c.character_id}
+                    checked={!excludedCharacterIds.has(c.character_id)}
+                    onCheckedChange={() => toggleCharacter(c.character_id)}
+                    onSelect={(e) => e.preventDefault()}
+                  >
+                    {c.character_name}
+                  </DropdownMenuCheckboxItem>
+                ))}
+              </DropdownMenuGroup>
+            ))}
           </DropdownMenuContent>
         </DropdownMenu>
       </div>
@@ -153,6 +197,9 @@ export function PlanComparisonTab({ planId }: PlanComparisonTabProps) {
               <TableRow>
                 <TableHead className="bg-background border-b">
                   Character
+                </TableHead>
+                <TableHead className="bg-background border-b">
+                  Account
                 </TableHead>
                 <TableHead className="text-right bg-background border-b">
                   Completed SP
@@ -181,6 +228,9 @@ export function PlanComparisonTab({ planId }: PlanComparisonTabProps) {
                 >
                   <TableCell className="font-medium">
                     {c.character_name}
+                  </TableCell>
+                  <TableCell className="text-muted-foreground">
+                    {characterAccountMap.get(c.character_id) ?? '—'}
                   </TableCell>
                   <TableCell className="text-right">
                     {formatNumber(c.completed_sp)}
@@ -215,7 +265,7 @@ export function PlanComparisonTab({ planId }: PlanComparisonTabProps) {
               {filteredComparisons.length === 0 && (
                 <TableRow>
                   <TableCell
-                    colSpan={5}
+                    colSpan={6}
                     className="text-center py-8 text-muted-foreground"
                   >
                     No characters selected or available.

--- a/src/components/SkillPlans/PlanComparisonTab.tsx
+++ b/src/components/SkillPlans/PlanComparisonTab.tsx
@@ -90,16 +90,20 @@ export function PlanComparisonTab({ planId }: PlanComparisonTabProps) {
   };
 
   const groupedComparisons = useMemo(() => {
-    if (!data || !accountsData) return [];
+    if (!data) return [];
+    if (!accountsData) {
+      return [{ label: 'All Characters', characters: data.comparisons }];
+    }
     const comparisonMap = new Map(
       data.comparisons.map((c) => [c.character_id, c])
     );
-    const groups: { label: string; characters: typeof data.comparisons }[] = [];
+    type Comparison = (typeof data.comparisons)[number];
+    const groups: { label: string; characters: Comparison[] }[] = [];
 
     for (const account of accountsData.accounts) {
       const chars = account.characters
         .map((c) => comparisonMap.get(c.character_id))
-        .filter(Boolean) as typeof data.comparisons;
+        .filter((c): c is Comparison => c !== undefined);
       if (chars.length > 0) {
         groups.push({ label: account.name, characters: chars });
       }
@@ -107,7 +111,7 @@ export function PlanComparisonTab({ planId }: PlanComparisonTabProps) {
 
     const unassignedChars = accountsData.unassigned_characters
       .map((c) => comparisonMap.get(c.character_id))
-      .filter(Boolean) as typeof data.comparisons;
+      .filter((c): c is Comparison => c !== undefined);
     if (unassignedChars.length > 0) {
       groups.push({ label: 'Unassigned', characters: unassignedChars });
     }


### PR DESCRIPTION
- Add account columns to skill comparison
- Add account dividers to filter dropdown
- Fix SP values in plan comparison to look at SP per level instead of rolling up