### PR TITLE
feat(plans): persist active tab across plan navigation

### DIFF
--- a/src/components/PlanTree/index.tsx
+++ b/src/components/PlanTree/index.tsx
@@ -137,7 +137,11 @@ export function PlanTree({
       if (onPlanClick) {
         onPlanClick(planId);
       } else {
-        navigate({ to: '/plans/$planId', params: { planId: String(planId) } });
+        navigate({
+          to: '/plans/$planId',
+          params: { planId: String(planId) },
+          search: (prev) => prev,
+        });
       }
     },
     [onPlanClick, navigate]


### PR DESCRIPTION
Clicking another plan in PlanTree carried no search params, so the ?tab selection reset to editor each switch