### PR TITLE
Create plans and folders directly in target folders

### DIFF
--- a/src-tauri/src/commands/skill_plans.rs
+++ b/src-tauri/src/commands/skill_plans.rs
@@ -187,6 +187,7 @@ async fn import_skill_plan_json_inner(
         &plan.name,
         plan.description.as_deref(),
         plan.auto_prerequisites,
+        None,
     )
     .await
     .map_err(|e| format!("Failed to create plan: {}", e))?;
@@ -320,8 +321,9 @@ pub async fn create_skill_plan(
     pool: State<'_, db::Pool>,
     name: String,
     description: Option<String>,
+    group_id: Option<i64>,
 ) -> Result<i64, String> {
-    db::skill_plans::create_skill_plan(&pool, &name, description.as_deref(), true)
+    db::skill_plans::create_skill_plan(&pool, &name, description.as_deref(), true, group_id)
         .await
         .map_err(|e| format!("Failed to create skill plan: {}", e))
 }
@@ -405,6 +407,7 @@ async fn create_merged_skill_plan_inner(
         name,
         description.map(str::trim).filter(|s| !s.is_empty()),
         true,
+        None,
     )
     .await?;
 
@@ -683,6 +686,7 @@ pub async fn create_plan_from_character(
             .map(|s| s.trim())
             .filter(|s| !s.is_empty()),
         true,
+        None,
     )
     .await
     .map_err(|e| format!("Failed to create plan: {}", e))?;

--- a/src-tauri/src/db/plan_groups.rs
+++ b/src-tauri/src/db/plan_groups.rs
@@ -7,7 +7,8 @@ use super::Pool;
 use crate::ts_types::i64_ts;
 
 /// Maximum allowed folder depth (groups live at depths 0, 1, 2).
-pub const MAX_DEPTH: i64 = 2;
+#[typeshare]
+pub const MAX_PLAN_GROUP_DEPTH: i64_ts = 2;
 
 #[typeshare]
 #[derive(Debug, Clone, Serialize, Deserialize, FromRow)]
@@ -49,7 +50,7 @@ pub async fn list(pool: &Pool) -> Result<Vec<PlanGroup>> {
 }
 
 /// Creates a folder under `parent_group_id` (NULL = root). Trims `name` and
-/// rejects empty input. Enforces `MAX_DEPTH` against the parent's depth so the
+/// rejects empty input. Enforces `MAX_PLAN_GROUP_DEPTH` against the parent's depth so the
 /// tree never exceeds the configured nesting limit. Appends to the end of the
 /// parent's children by assigning the next free `sort_order`.
 pub async fn create(pool: &Pool, name: &str, parent_group_id: Option<i64>) -> Result<i64> {
@@ -77,10 +78,10 @@ pub async fn create(pool: &Pool, name: &str, parent_group_id: Option<i64>) -> Re
 
         let depth = parent_depth.ok_or_else(|| anyhow!("Parent folder {} not found", parent_id))?;
 
-        if depth >= MAX_DEPTH {
+        if depth >= MAX_PLAN_GROUP_DEPTH {
             return Err(anyhow!(
                 "Cannot create folder: maximum nesting depth of {} levels reached",
-                MAX_DEPTH + 1
+                MAX_PLAN_GROUP_DEPTH + 1
             ));
         }
 
@@ -212,7 +213,7 @@ pub async fn delete_group(pool: &Pool, group_id: i64, cascade_plans: bool) -> Re
 /// - for folder moves, the destination is not the moved folder itself nor any
 ///   of its descendants (cycle check);
 /// - for folder moves, the moved subtree's depth at the new location does not
-///   exceed `MAX_DEPTH`.
+///   exceed `MAX_PLAN_GROUP_DEPTH`.
 ///
 /// Renumbers both the new parent's children (placing the moved node at
 /// `new_sort_order`) and, if the parent changed, the old parent's children
@@ -297,7 +298,7 @@ pub async fn move_node(pool: &Pool, payload: MoveNodePayload) -> Result<()> {
             }
         }
 
-        // Depth check: subtree-depth of moved group + (new parent depth + 1) <= MAX_DEPTH.
+        // Depth check: subtree-depth of moved group + (new parent depth + 1) <= MAX_PLAN_GROUP_DEPTH.
         let subtree_depth: i64 = sqlx::query_scalar(
             "WITH RECURSIVE subtree(group_id, depth) AS (
                  SELECT group_id, 0 FROM plan_groups WHERE group_id = ?
@@ -312,10 +313,10 @@ pub async fn move_node(pool: &Pool, payload: MoveNodePayload) -> Result<()> {
         .await?;
 
         let moved_depth = new_parent_depth + 1;
-        if moved_depth + subtree_depth > MAX_DEPTH {
+        if moved_depth + subtree_depth > MAX_PLAN_GROUP_DEPTH {
             return Err(anyhow!(
                 "Cannot move folder: would exceed maximum nesting depth of {} levels",
-                MAX_DEPTH + 1
+                MAX_PLAN_GROUP_DEPTH + 1
             ));
         }
     }

--- a/src-tauri/src/db/skill_plans.rs
+++ b/src-tauri/src/db/skill_plans.rs
@@ -35,16 +35,50 @@ pub async fn create_skill_plan(
     name: &str,
     description: Option<&str>,
     auto_prerequisites: bool,
+    group_id: Option<i64>,
 ) -> Result<i64> {
     let now = chrono::Utc::now().timestamp();
+
+    // Place the new plan at the end of its target folder (NULL = root). Sibling
+    // sort_order is shared between subfolders and plans under the same parent, so
+    // take the max across both tables.
+    let sort_order: i64 = match group_id {
+        Some(gid) => {
+            sqlx::query_scalar(
+                "SELECT COALESCE(MAX(so), -1) + 1 FROM (
+                     SELECT sort_order AS so FROM skill_plans WHERE group_id = ?
+                     UNION ALL
+                     SELECT sort_order AS so FROM plan_groups WHERE parent_group_id = ?
+                 )",
+            )
+            .bind(gid)
+            .bind(gid)
+            .fetch_one(pool)
+            .await?
+        }
+        None => {
+            sqlx::query_scalar(
+                "SELECT COALESCE(MAX(so), -1) + 1 FROM (
+                     SELECT sort_order AS so FROM skill_plans WHERE group_id IS NULL
+                     UNION ALL
+                     SELECT sort_order AS so FROM plan_groups WHERE parent_group_id IS NULL
+                 )",
+            )
+            .fetch_one(pool)
+            .await?
+        }
+    };
+
     let result = sqlx::query(
-        "INSERT INTO skill_plans (name, description, auto_prerequisites, created_at, updated_at) VALUES (?, ?, ?, ?, ?)",
+        "INSERT INTO skill_plans (name, description, auto_prerequisites, created_at, updated_at, group_id, sort_order) VALUES (?, ?, ?, ?, ?, ?, ?)",
     )
     .bind(name)
     .bind(description)
     .bind(if auto_prerequisites { 1 } else { 0 })
     .bind(now)
     .bind(now)
+    .bind(group_id)
+    .bind(sort_order)
     .execute(pool)
     .await?;
 

--- a/src-tauri/src/testdata/fixtures.rs
+++ b/src-tauri/src/testdata/fixtures.rs
@@ -17,7 +17,7 @@ struct JsonSkillPlanEntry {
 }
 
 pub async fn create_skill_plan(pool: &Pool, name: &str) -> i64 {
-    db::skill_plans::create_skill_plan(pool, name, None, false)
+    db::skill_plans::create_skill_plan(pool, name, None, false, None)
         .await
         .unwrap()
 }

--- a/src/components/PlanTree/CreatePlanDialog.tsx
+++ b/src/components/PlanTree/CreatePlanDialog.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useMemo, useState } from 'react';
 
 import { Button } from '@/components/ui/button';
 import {
@@ -11,23 +11,90 @@ import {
 } from '@/components/ui/dialog';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
 import { Textarea } from '@/components/ui/textarea';
+import type { PlanGroup } from '@/generated/types';
+import { usePlanGroups } from '@/hooks/tauri/usePlanGroups';
 import { useCreateSkillPlan } from '@/hooks/tauri/useSkillPlans';
+
+const ROOT_VALUE = '__root__';
 
 interface CreatePlanDialogProps {
   open: boolean;
   onOpenChange: (open: boolean) => void;
+  initialGroupId?: number | null;
   onSuccess?: (planId: number) => void;
+}
+
+interface FolderOption {
+  groupId: number;
+  label: string;
+}
+
+function buildFolderOptions(groups: PlanGroup[]): FolderOption[] {
+  const childrenByParent = new Map<number | null, PlanGroup[]>();
+  for (const g of groups) {
+    const key = g.parent_group_id ?? null;
+    const arr = childrenByParent.get(key) ?? [];
+    arr.push(g);
+    childrenByParent.set(key, arr);
+  }
+  for (const arr of childrenByParent.values()) {
+    arr.sort((a, b) =>
+      a.sort_order !== b.sort_order
+        ? a.sort_order - b.sort_order
+        : a.group_id - b.group_id
+    );
+  }
+
+  const out: FolderOption[] = [];
+  const walk = (parentId: number | null, depth: number) => {
+    for (const g of childrenByParent.get(parentId) ?? []) {
+      out.push({
+        groupId: g.group_id,
+        label: `${'  '.repeat(depth)}${g.name}`,
+      });
+      walk(g.group_id, depth + 1);
+    }
+  };
+  walk(null, 0);
+  return out;
 }
 
 export function CreatePlanDialog({
   open,
   onOpenChange,
+  initialGroupId = null,
   onSuccess,
 }: CreatePlanDialogProps) {
   const [name, setName] = useState('');
   const [description, setDescription] = useState('');
+  const [folderValue, setFolderValue] = useState<string>(
+    initialGroupId == null ? ROOT_VALUE : String(initialGroupId)
+  );
+  const { data: groups } = usePlanGroups();
   const createPlanMutation = useCreateSkillPlan();
+
+  const options = useMemo(() => buildFolderOptions(groups ?? []), [groups]);
+
+  // Seed the folder selection from the folder the create was launched from each
+  // time the dialog transitions to open — done during render (not an effect) per
+  // React's "adjust state when a prop changes" guidance.
+  const [prevOpen, setPrevOpen] = useState(open);
+  if (open !== prevOpen) {
+    setPrevOpen(open);
+    if (open) {
+      setFolderValue(
+        initialGroupId == null ? ROOT_VALUE : String(initialGroupId)
+      );
+    }
+  }
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
@@ -37,6 +104,7 @@ export function CreatePlanDialog({
       const planId = await createPlanMutation.mutateAsync({
         name: name.trim(),
         description: description.trim() || undefined,
+        groupId: folderValue === ROOT_VALUE ? null : Number(folderValue),
       });
       setName('');
       setDescription('');
@@ -80,6 +148,22 @@ export function CreatePlanDialog({
                 placeholder="Enter plan description"
                 rows={3}
               />
+            </div>
+            <div className="space-y-2">
+              <Label htmlFor="plan-folder">Folder</Label>
+              <Select value={folderValue} onValueChange={setFolderValue}>
+                <SelectTrigger id="plan-folder">
+                  <SelectValue placeholder="Choose a folder" />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value={ROOT_VALUE}>Root</SelectItem>
+                  {options.map((opt) => (
+                    <SelectItem key={opt.groupId} value={String(opt.groupId)}>
+                      {opt.label}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
             </div>
             {createPlanMutation.isError && (
               <p className="text-sm text-destructive">

--- a/src/components/PlanTree/CreatePlanGroupDialog.tsx
+++ b/src/components/PlanTree/CreatePlanGroupDialog.tsx
@@ -21,8 +21,11 @@ import {
 import type { PlanGroup } from '@/generated/types';
 import { useCreatePlanGroup, usePlanGroups } from '@/hooks/tauri/usePlanGroups';
 
-const MAX_DEPTH = 2;
+const MAX_PLAN_GROUP_DEPTH = 2;
 const ROOT_VALUE = '__root__';
+
+const toParentValue = (id: number | null) =>
+  id == null ? ROOT_VALUE : String(id);
 
 interface CreatePlanGroupDialogProps {
   open: boolean;
@@ -64,7 +67,7 @@ function buildParentOptions(groups: PlanGroup[]): OptionRow[] {
         groupId: g.group_id,
         label: `${'  '.repeat(depth)}${g.name}`,
         depth,
-        disabled: depth >= MAX_DEPTH,
+        disabled: depth >= MAX_PLAN_GROUP_DEPTH,
       });
       walk(g.group_id, depth + 1);
     }
@@ -81,19 +84,27 @@ export function CreatePlanGroupDialog({
 }: CreatePlanGroupDialogProps) {
   const [name, setName] = useState('');
   const [parentValue, setParentValue] = useState<string>(
-    initialParentGroupId == null ? ROOT_VALUE : String(initialParentGroupId)
+    toParentValue(initialParentGroupId)
   );
   const { data: groups } = usePlanGroups();
   const createMutation = useCreatePlanGroup();
 
   const options = useMemo(() => buildParentOptions(groups ?? []), [groups]);
 
+  // Re-seed the parent selection from the folder the create was launched from
+  // each time the dialog transitions to open — done during render (not an
+  // effect) per React's "adjust state when a prop changes" guidance.
+  const [prevOpen, setPrevOpen] = useState(open);
+  if (open !== prevOpen) {
+    setPrevOpen(open);
+    if (open) {
+      setParentValue(toParentValue(initialParentGroupId));
+    }
+  }
+
   const handleOpenChange = (next: boolean) => {
     if (!next) {
       setName('');
-      setParentValue(
-        initialParentGroupId == null ? ROOT_VALUE : String(initialParentGroupId)
-      );
       createMutation.reset();
     }
     onOpenChange(next);

--- a/src/components/PlanTree/CreatePlanGroupDialog.tsx
+++ b/src/components/PlanTree/CreatePlanGroupDialog.tsx
@@ -18,10 +18,9 @@ import {
   SelectTrigger,
   SelectValue,
 } from '@/components/ui/select';
-import type { PlanGroup } from '@/generated/types';
+import { MAX_PLAN_GROUP_DEPTH, type PlanGroup } from '@/generated/types';
 import { useCreatePlanGroup, usePlanGroups } from '@/hooks/tauri/usePlanGroups';
 
-const MAX_PLAN_GROUP_DEPTH = 2;
 const ROOT_VALUE = '__root__';
 
 const toParentValue = (id: number | null) =>
@@ -135,7 +134,8 @@ export function CreatePlanGroupDialog({
           <DialogHeader>
             <DialogTitle>Create Folder</DialogTitle>
             <DialogDescription>
-              Folders organise plans into a tree (up to 3 levels deep).
+              Folders organise plans into a tree (up to{' '}
+              {MAX_PLAN_GROUP_DEPTH + 1} levels deep).
             </DialogDescription>
           </DialogHeader>
           <div className="space-y-4 py-4">

--- a/src/components/PlanTree/PlanTreeDialogs.tsx
+++ b/src/components/PlanTree/PlanTreeDialogs.tsx
@@ -47,6 +47,7 @@ export function PlanTreeDialogs() {
         onOpenChange={(open) => {
           if (!open) closeDialog();
         }}
+        initialGroupId={dialog.kind === 'createPlan' ? dialog.groupId : null}
         onSuccess={handleCreateSuccess}
       />
       <CreateMergedPlanDialog

--- a/src/components/PlanTree/PlanTreeDialogs.tsx
+++ b/src/components/PlanTree/PlanTreeDialogs.tsx
@@ -78,6 +78,9 @@ export function PlanTreeDialogs() {
         onOpenChange={(open) => {
           if (!open) closeDialog();
         }}
+        initialParentGroupId={
+          dialog.kind === 'createPlanGroup' ? dialog.parentGroupId : null
+        }
       />
       <DeletePlanGroupDialog
         open={dialog.kind === 'deletePlanGroup'}

--- a/src/components/PlanTree/index.tsx
+++ b/src/components/PlanTree/index.tsx
@@ -47,6 +47,11 @@ import { PlanTreeDialogs } from './PlanTreeDialogs';
 
 type PlanItem = TreeNode;
 
+// Deepest 0-indexed depth a folder may occupy; a folder accepts a child folder
+// only while its own depth is strictly below this. Mirrors MAX_DEPTH in
+// src-tauri/src/db/plan_groups.rs and CreatePlanGroupDialog.tsx.
+const MAX_PLAN_GROUP_DEPTH = 2;
+
 function useExpandedGroupTreeState() {
   const { data: persistedExpanded } = useExpandedPlanGroups();
   const persistExpanded = usePersistExpandedPlanGroups();
@@ -172,7 +177,7 @@ export function PlanTree({
     isDropAllowed(sourceId, target, nodeIndex);
 
   const treeData: PlanItem[] = useMemo(() => {
-    const build = (node: PlanTreeNode): PlanItem => {
+    const build = (node: PlanTreeNode, depth: number): PlanItem => {
       if (node.kind === 'group') {
         return {
           id: groupNodeId(node.id),
@@ -181,13 +186,19 @@ export function PlanTree({
           openIcon: FolderOpen,
           draggable: true,
           droppable: true,
-          children: node.children.map(build),
+          children: node.children.map((child) => build(child, depth + 1)),
           contextMenuContent: showActions ? (
             <>
               <ContextMenuItem onSelect={() => openCreatePlan(node.id)}>
                 <FilePlus className="size-3.5" />
                 New Plan Here
               </ContextMenuItem>
+              {depth < MAX_PLAN_GROUP_DEPTH && (
+                <ContextMenuItem onSelect={() => openCreatePlanGroup(node.id)}>
+                  <FolderPlus className="size-3.5" />
+                  New Folder Here
+                </ContextMenuItem>
+              )}
               <ContextMenuItem
                 onSelect={() => openRenamePlanGroup(node.id, node.name)}
               >
@@ -223,12 +234,13 @@ export function PlanTree({
         ) : undefined,
       } satisfies PlanItem;
     };
-    return tree.map(build);
+    return tree.map((node) => build(node, 0));
   }, [
     tree,
     showActions,
     handlePlanClick,
     openCreatePlan,
+    openCreatePlanGroup,
     openRenamePlanGroup,
     openDeletePlanGroup,
     openDeletePlan,
@@ -286,7 +298,7 @@ export function PlanTree({
                 <DropdownMenuItem onClick={openCreatePlanFromCharacter}>
                   Create Plan from Character
                 </DropdownMenuItem>
-                <DropdownMenuItem onClick={openCreatePlanGroup}>
+                <DropdownMenuItem onClick={() => openCreatePlanGroup()}>
                   <FolderPlus className="size-4 mr-2" />
                   Create Folder
                 </DropdownMenuItem>

--- a/src/components/PlanTree/index.tsx
+++ b/src/components/PlanTree/index.tsx
@@ -1,6 +1,7 @@
 import { useNavigate, useParams } from '@tanstack/react-router';
 import {
   ChevronDown,
+  FilePlus,
   FileText,
   Folder,
   FolderOpen,
@@ -183,6 +184,10 @@ export function PlanTree({
           children: node.children.map(build),
           contextMenuContent: showActions ? (
             <>
+              <ContextMenuItem onSelect={() => openCreatePlan(node.id)}>
+                <FilePlus className="size-3.5" />
+                New Plan Here
+              </ContextMenuItem>
               <ContextMenuItem
                 onSelect={() => openRenamePlanGroup(node.id, node.name)}
               >
@@ -223,6 +228,7 @@ export function PlanTree({
     tree,
     showActions,
     handlePlanClick,
+    openCreatePlan,
     openRenamePlanGroup,
     openDeletePlanGroup,
     openDeletePlan,
@@ -256,7 +262,10 @@ export function PlanTree({
       {showActions && (
         <div className="p-4 border-b border-border">
           <div className="flex w-full">
-            <Button onClick={openCreatePlan} className="flex-1 rounded-r-none">
+            <Button
+              onClick={() => openCreatePlan()}
+              className="flex-1 rounded-r-none"
+            >
               Create Plan
             </Button>
             <DropdownMenu>

--- a/src/components/PlanTree/index.tsx
+++ b/src/components/PlanTree/index.tsx
@@ -26,6 +26,7 @@ import {
   DropdownMenuItem,
   DropdownMenuTrigger,
 } from '@/components/ui/dropdown-menu';
+import { MAX_PLAN_GROUP_DEPTH } from '@/generated/types';
 import {
   useExpandedPlanGroups,
   usePersistExpandedPlanGroups,
@@ -46,11 +47,6 @@ import { usePlanTreeDialogStore } from '@/stores/planTreeDialogStore';
 import { PlanTreeDialogs } from './PlanTreeDialogs';
 
 type PlanItem = TreeNode;
-
-// Deepest 0-indexed depth a folder may occupy; a folder accepts a child folder
-// only while its own depth is strictly below this. Mirrors MAX_DEPTH in
-// src-tauri/src/db/plan_groups.rs and CreatePlanGroupDialog.tsx.
-const MAX_PLAN_GROUP_DEPTH = 2;
 
 function useExpandedGroupTreeState() {
   const { data: persistedExpanded } = useExpandedPlanGroups();

--- a/src/hooks/tauri/useSkillPlans.ts
+++ b/src/hooks/tauri/useSkillPlans.ts
@@ -18,6 +18,7 @@ interface CreateSkillPlanParams {
   name: string;
   description?: string;
   autoPrerequisites?: boolean;
+  groupId?: number | null;
 }
 
 interface CreateMergedSkillPlanParams {

--- a/src/stores/planTreeDialogStore.ts
+++ b/src/stores/planTreeDialogStore.ts
@@ -2,7 +2,7 @@ import { create } from 'zustand';
 
 export type PlanTreeDialog =
   | { kind: 'none' }
-  | { kind: 'createPlan' }
+  | { kind: 'createPlan'; groupId: number | null }
   | { kind: 'createMergedPlan' }
   | { kind: 'createPlanFromCharacter' }
   | { kind: 'createPlanGroup' }
@@ -12,7 +12,7 @@ export type PlanTreeDialog =
 
 interface PlanTreeDialogState {
   dialog: PlanTreeDialog;
-  openCreatePlan: () => void;
+  openCreatePlan: (groupId?: number | null) => void;
   openCreateMergedPlan: () => void;
   openCreatePlanFromCharacter: () => void;
   openCreatePlanGroup: () => void;
@@ -24,7 +24,8 @@ interface PlanTreeDialogState {
 
 export const usePlanTreeDialogStore = create<PlanTreeDialogState>((set) => ({
   dialog: { kind: 'none' },
-  openCreatePlan: () => set({ dialog: { kind: 'createPlan' } }),
+  openCreatePlan: (groupId = null) =>
+    set({ dialog: { kind: 'createPlan', groupId } }),
   openCreateMergedPlan: () => set({ dialog: { kind: 'createMergedPlan' } }),
   openCreatePlanFromCharacter: () =>
     set({ dialog: { kind: 'createPlanFromCharacter' } }),

--- a/src/stores/planTreeDialogStore.ts
+++ b/src/stores/planTreeDialogStore.ts
@@ -1,11 +1,12 @@
 import { create } from 'zustand';
 
+// On createPlan/createPlanGroup, a null groupId/parentGroupId means "create at root".
 export type PlanTreeDialog =
   | { kind: 'none' }
   | { kind: 'createPlan'; groupId: number | null }
   | { kind: 'createMergedPlan' }
   | { kind: 'createPlanFromCharacter' }
-  | { kind: 'createPlanGroup' }
+  | { kind: 'createPlanGroup'; parentGroupId: number | null }
   | { kind: 'renamePlanGroup'; groupId: number; currentName: string }
   | { kind: 'deletePlanGroup'; groupId: number; name: string }
   | { kind: 'deletePlan'; planId: number; name: string };
@@ -15,7 +16,7 @@ interface PlanTreeDialogState {
   openCreatePlan: (groupId?: number | null) => void;
   openCreateMergedPlan: () => void;
   openCreatePlanFromCharacter: () => void;
-  openCreatePlanGroup: () => void;
+  openCreatePlanGroup: (parentGroupId?: number | null) => void;
   openRenamePlanGroup: (groupId: number, currentName: string) => void;
   openDeletePlanGroup: (groupId: number, name: string) => void;
   openDeletePlan: (planId: number, name: string) => void;
@@ -29,7 +30,8 @@ export const usePlanTreeDialogStore = create<PlanTreeDialogState>((set) => ({
   openCreateMergedPlan: () => set({ dialog: { kind: 'createMergedPlan' } }),
   openCreatePlanFromCharacter: () =>
     set({ dialog: { kind: 'createPlanFromCharacter' } }),
-  openCreatePlanGroup: () => set({ dialog: { kind: 'createPlanGroup' } }),
+  openCreatePlanGroup: (parentGroupId = null) =>
+    set({ dialog: { kind: 'createPlanGroup', parentGroupId } }),
   openRenamePlanGroup: (groupId, currentName) =>
     set({ dialog: { kind: 'renamePlanGroup', groupId, currentName } }),
   openDeletePlanGroup: (groupId, name) =>


### PR DESCRIPTION
## Summary

Lets users create plans and folders **directly inside a folder** instead of only at the tree root. Picking "New plan" / "New folder" from a folder's context now seeds the dialog with that folder as the parent, and the new item lands at the end of that folder's children.

## Changes

**Backend**
- `create_skill_plan` now accepts `group_id`. The new plan is placed at the end of its target folder (NULL = root), computing `sort_order` as the max across sibling plans **and** subfolders under the same parent (sort order is shared between the two).
- Folder creation follows the same pattern via `parent_group_id`, with the existing nesting-depth limit still enforced.
- Renamed `MAX_DEPTH` → `MAX_PLAN_GROUP_DEPTH` and exported it via `#[typeshare]` so the frontend uses the shared constant instead of hardcoding the limit.

**Frontend**
- `planTreeDialogStore`: `createPlan` / `createPlanGroup` dialogs carry a `groupId` / `parentGroupId` (`null` = root); `openCreatePlan(groupId?)` / `openCreatePlanGroup(parentGroupId?)`.
- `CreatePlanDialog`, `CreatePlanGroupDialog`, `PlanTreeDialogs`, and the tree index pass the target folder through.
