### PR TITLE
fix(plans): scope plan total SP to per-level slices

### DIFF
--- a/src-tauri/src/commands/skill_plans.rs
+++ b/src-tauri/src/commands/skill_plans.rs
@@ -784,7 +784,7 @@ pub async fn get_skill_plan_with_entries(
         let skill_attr = skill_attributes.get(&entry.skill_type_id);
         let rank = skill_attr.and_then(|attr| attr.rank);
         let skillpoints_for_level = if let Some(rank_val) = rank {
-            utils::calculate_sp_for_level(rank_val, entry.planned_level as i32)
+            utils::sp_for_level_slice(rank_val, entry.planned_level as i32)
         } else {
             0
         };

--- a/src-tauri/src/skill_plans/plan_from_character.rs
+++ b/src-tauri/src/skill_plans/plan_from_character.rs
@@ -114,7 +114,7 @@ pub async fn build_plan_from_character(
             .get(&node.skill_type_id)
             .and_then(|a| a.rank)
             .unwrap_or(1);
-        estimated_sp += utils::calculate_sp_for_level(rank, node.level as i32);
+        estimated_sp += utils::sp_for_level_slice(rank, node.level as i32);
 
         let group_id = get_skill_group_id_cached(pool, node.skill_type_id, &mut group_id_cache)
             .await?

--- a/src-tauri/src/utils.rs
+++ b/src-tauri/src/utils.rs
@@ -122,3 +122,42 @@ pub fn calculate_sp_for_level(rank: i64, level: i32) -> i64 {
     let base_sp = (base.powf(exponent) * 250.0).ceil();
     (base_sp * rank as f64) as i64
 }
+
+/// SP required for a single skill level, excluding all lower levels.
+///
+/// `calculate_sp_for_level` is cumulative from 0, so summing it across the
+/// per-level rows of a plan (a skill stored as levels 1..=5) double-counts.
+/// Summing this slice instead telescopes back to the cumulative total.
+pub fn sp_for_level_slice(rank: i64, level: i32) -> i64 {
+    calculate_sp_for_level(rank, level) - calculate_sp_for_level(rank, level - 1)
+}
+
+#[cfg(test)]
+mod sp_slice_tests {
+    use super::*;
+
+    #[test]
+    fn slice_sums_to_cumulative() {
+        let rank = 5;
+        let slices: i64 = (1..=5).map(|l| sp_for_level_slice(rank, l)).sum();
+        assert_eq!(slices, calculate_sp_for_level(rank, 5));
+    }
+
+    #[test]
+    fn level_one_slice_is_full_level_one() {
+        let rank = 3;
+        assert_eq!(sp_for_level_slice(rank, 1), calculate_sp_for_level(rank, 1));
+    }
+
+    #[test]
+    fn each_slice_is_positive_and_increasing() {
+        let rank = 1;
+        let mut prev = 0;
+        for l in 1..=5 {
+            let slice = sp_for_level_slice(rank, l);
+            assert!(slice > 0, "level {l} slice not positive");
+            assert!(slice > prev, "level {l} slice not larger than previous");
+            prev = slice;
+        }
+    }
+}


### PR DESCRIPTION
## Problem

`calculate_sp_for_level(rank, level)` returns **cumulative** SP from 0→level. Plans store one entry per level (a skill = rows L1..L5), so summing the cumulative value across rows double-counts. A full-to-L5 plan showed **~21% too much SP** (ratio is rank-independent, so uniform).

Verified against live data: plan 6 stores 5 rows per skill (levels 1,2,3,4,5).

Same root cause as the plan-comparison fix (6b0df30) — missed in two plan-total paths.

## Fix

New shared helper `utils::sp_for_level_slice(rank, level)` = `cumulative(level) − cumulative(level−1)`; per-level slices telescope back to the cumulative total. Applied at both sites:

- `commands/skill_plans.rs` — `skillpoints_for_level` in `get_skill_plan_with_entries` (frontend `PlanEditor` total + progress bar, `PlanEntryRow` per-row SP/% all treat it as a slice)
- `skill_plans/plan_from_character.rs` — `estimated_sp` ("create plan from character" preview total)

Ruled out: `simulation.rs` / `optimization.rs` totals — they track a per-skill running SP map keyed by `skill_type_id`, so no double-count.

## Tests

- New `sp_slice_tests` in `utils.rs`: slices sum to cumulative, L1 slice == full L1, slices positive + increasing
- Full suite: 74/74 pass, no regression