### PR TITLE
fix(overview): make Alpha icon visible in overview table

### DIFF
--- a/src/components/OverviewTableRow.tsx
+++ b/src/components/OverviewTableRow.tsx
@@ -63,7 +63,7 @@ export function OverviewTableRow({ character }: OverviewTableRowProps) {
           </span>
           {!character.isOmega && (
             <span title="Alpha Clone">
-              <AlphaIcon className="h-4 w-4 text-primary-foreground" />
+              <AlphaIcon className="h-4 w-4 text-white" />
             </span>
           )}
         </div>


### PR DESCRIPTION
text-primary-foreground painted the stroked SVG in a near-background color, rendering it invisible. Use text-white to match the detail page Alpha icon.

Closes #98