### PR TITLE
chore(esi): reqwest 0.13 + oas3-gen 0.26 client-mod migration

### DIFF
--- a/.claude/rules/development-guidelines.md
+++ b/.claude/rules/development-guidelines.md
@@ -84,4 +84,4 @@ Components land in `src/components/ui/` automatically. Config is in `components.
 
 - `src/generated/` (types only) — run `pnpm typegen` after any Rust struct change
 - `routeTree.gen.ts` — managed by the TanStack Router Vite plugin
-- `src-tauri/src/esi/client.rs`, `types.rs` — run `./scripts/generate-esi.sh` to regenerate
+- `src-tauri/src/esi/generated/` (`oas3-gen` client-mod output) — run `./scripts/generate-esi.sh` to regenerate

--- a/.claude/rules/esi-client.md
+++ b/.claude/rules/esi-client.md
@@ -8,15 +8,14 @@ paths:
 
 ## Overview
 
-The ESI client (`src-tauri/src/esi/`) is auto-generated from the EVE Online OpenAPI schema. Use `./scripts/generate-esi.sh` to regenerate. Never edit `client.rs` or `types.rs` manually.
+The ESI client (`src-tauri/src/esi/`) is auto-generated from the EVE Online OpenAPI schema. Use `./scripts/generate-esi.sh` to regenerate. Never edit anything under `generated/` manually.
 
 ## Files
 
 | File | Description |
 |------|-------------|
-| `mod.rs` | Module exports, `BASE_URL`, `BASE_SCOPES` |
-| `client.rs` | **Generated** — do not edit |
-| `types.rs` | **Generated** — do not edit |
+| `mod.rs` | Module exports; re-exports `generated::*` (client, types, `BASE_URL`) |
+| `generated/` | **Generated** (`oas3-gen` client-mod: `mod.rs`/`client.rs`/`types.rs`) — do not edit; gitignored |
 | `scopes.rs` | `EsiScope` enum, `BASE_SCOPES` constant |
 | `cached.rs` | `fetch_cached()` — unified caching + rate limit tracking |
 | `openapi.json` | Cached OpenAPI schema |

--- a/.claude/rules/project-setup.md
+++ b/.claude/rules/project-setup.md
@@ -33,7 +33,7 @@ Do not run a full build solely to regenerate frontend bindings — use `pnpm typ
 
 ## ESI Client Generation
 
-The ESI client (`src-tauri/src/esi/client.rs`, `types.rs`) is auto-generated from the EVE Online OpenAPI schema. Only regenerate when the ESI API schema changes.
+The ESI client (`src-tauri/src/esi/generated/`) is auto-generated from the EVE Online OpenAPI schema. Only regenerate when the ESI API schema changes.
 
 ```bash
 ./scripts/generate-esi.sh

--- a/.github/workflows/build-adhoc.yml
+++ b/.github/workflows/build-adhoc.yml
@@ -87,11 +87,11 @@ jobs:
           path: |
             ~/.cargo/bin/oas3-gen
             ~/.cargo/bin/oas3-gen.exe
-          key: ${{ runner.os }}-oas3-gen-0.26.1
+          key: ${{ runner.os }}-oas3-gen-fork-fix-92
 
       - name: Install oas3-gen
         if: steps.cache-oas3-gen.outputs.cache-hit != 'true'
-        run: cargo install oas3-gen --version 0.26.1 --force
+        run: cargo install --git https://github.com/snipereagle1/oas3-gen --branch fix/92-required-header-default oas3-gen --force
 
       - name: Cache typeshare-cli
         id: cache-typeshare-cli

--- a/.github/workflows/build-adhoc.yml
+++ b/.github/workflows/build-adhoc.yml
@@ -87,11 +87,11 @@ jobs:
           path: |
             ~/.cargo/bin/oas3-gen
             ~/.cargo/bin/oas3-gen.exe
-          key: ${{ runner.os }}-oas3-gen-0.22.1
+          key: ${{ runner.os }}-oas3-gen-0.26.1
 
       - name: Install oas3-gen
         if: steps.cache-oas3-gen.outputs.cache-hit != 'true'
-        run: cargo install oas3-gen --version 0.22.1 --force
+        run: cargo install oas3-gen --version 0.26.1 --force
 
       - name: Cache typeshare-cli
         id: cache-typeshare-cli

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -96,13 +96,13 @@ jobs:
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
         with:
           path: ~/.cargo/bin/oas3-gen
-          key: ${{ runner.os }}-oas3-gen-0.22.1
+          key: ${{ runner.os }}-oas3-gen-0.26.1
 
       - name: Install oas3-gen
         if: steps.cache-oas3-gen.outputs.cache-hit != 'true'
-        run: cargo install oas3-gen --version 0.22.1 --force
+        run: cargo install oas3-gen --version 0.26.1 --force
 
-      # ESI client (esi/client.rs, esi/types.rs) is generated, not committed —
+      # ESI client (esi/generated/) is generated, not committed —
       # the crate will not compile without it.
       - name: Generate ESI client
         run: bash scripts/generate-esi.sh

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -96,11 +96,11 @@ jobs:
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
         with:
           path: ~/.cargo/bin/oas3-gen
-          key: ${{ runner.os }}-oas3-gen-0.26.1
+          key: ${{ runner.os }}-oas3-gen-fork-fix-92
 
       - name: Install oas3-gen
         if: steps.cache-oas3-gen.outputs.cache-hit != 'true'
-        run: cargo install oas3-gen --version 0.26.1 --force
+        run: cargo install --git https://github.com/snipereagle1/oas3-gen --branch fix/92-required-header-default oas3-gen --force
 
       # ESI client (esi/generated/) is generated, not committed —
       # the crate will not compile without it.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -116,11 +116,11 @@ jobs:
           path: |
             ~/.cargo/bin/oas3-gen
             ~/.cargo/bin/oas3-gen.exe
-          key: ${{ runner.os }}-oas3-gen-0.26.1
+          key: ${{ runner.os }}-oas3-gen-fork-fix-92
 
       - name: Install oas3-gen
         if: steps.cache-oas3-gen.outputs.cache-hit != 'true'
-        run: cargo install oas3-gen --version 0.26.1 --force
+        run: cargo install --git https://github.com/snipereagle1/oas3-gen --branch fix/92-required-header-default oas3-gen --force
 
       - name: Cache typeshare-cli
         id: cache-typeshare-cli

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -116,11 +116,11 @@ jobs:
           path: |
             ~/.cargo/bin/oas3-gen
             ~/.cargo/bin/oas3-gen.exe
-          key: ${{ runner.os }}-oas3-gen-0.22.1
+          key: ${{ runner.os }}-oas3-gen-0.26.1
 
       - name: Install oas3-gen
         if: steps.cache-oas3-gen.outputs.cache-hit != 'true'
-        run: cargo install oas3-gen --version 0.22.1 --force
+        run: cargo install oas3-gen --version 0.26.1 --force
 
       - name: Cache typeshare-cli
         id: cache-typeshare-cli

--- a/.gitignore
+++ b/.gitignore
@@ -25,8 +25,7 @@ dist-ssr
 .fallow/
 
 # Generated ESI code
-src-tauri/src/esi/client.rs
-src-tauri/src/esi/types.rs
+src-tauri/src/esi/generated/
 src-tauri/src/esi/openapi.json
 
 # Generated TypeScript bindings

--- a/scripts/generate-esi.sh
+++ b/scripts/generate-esi.sh
@@ -27,11 +27,6 @@ echo "Generating ESI client module..."
 rm -rf "$GEN_DIR"
 oas3-gen generate client-mod -i openapi.json -o "$GEN_DIR" --exclude get_meta_changelog --no-ordered-collections
 
-# Work around oas3-gen 0.26.1 bug: x_compatibility_date is a required (non-Option)
-# NaiveDate header, but the generated HeaderMap conversion wraps it in `if let Some(..)`.
-echo "Fixing x_compatibility_date header generation..."
-perl -0pi -e 's/if let Some\(value\) = &headers\.x_compatibility_date \{/\{ let value = &headers.x_compatibility_date;/g' "$GEN_DIR/types.rs" "$GEN_DIR/client.rs"
-
 # The generated mod.rs allows several clippy lints but not every style lint the code
 # trips (needless_return, needless_question_mark, ...). A module-level allow propagates
 # to the child modules, so one blanket allow on this never-hand-edited module makes

--- a/scripts/generate-esi.sh
+++ b/scripts/generate-esi.sh
@@ -27,11 +27,7 @@ echo "Generating ESI client module..."
 rm -rf "$GEN_DIR"
 oas3-gen generate client-mod -i openapi.json -o "$GEN_DIR" --exclude get_meta_changelog --no-ordered-collections
 
-# The generated mod.rs allows several clippy lints but not every style lint the code
-# trips (needless_return, needless_question_mark, ...). A module-level allow propagates
-# to the child modules, so one blanket allow on this never-hand-edited module makes
-# `clippy -D warnings` pass.
-echo "Suppressing clippy warnings on generated code..."
-perl -pi -e '$_ = "#![allow(clippy::all)]\n" . $_ if $. == 1' "$GEN_DIR/mod.rs"
+# Clippy suppression for the generated code lives on the `mod generated;` declaration
+# in src/esi/mod.rs (`#[allow(clippy::all)]`) — no post-generation patching needed.
 
 echo "Done! Generated ESI module in $GEN_DIR"

--- a/scripts/generate-esi.sh
+++ b/scripts/generate-esi.sh
@@ -4,24 +4,39 @@ set -e
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 ESI_DIR="$REPO_ROOT/src-tauri/src/esi"
+GEN_DIR="$ESI_DIR/generated"
 
 cd "$ESI_DIR"
 
-echo "Downloading ESI OpenAPI schema..."
-curl -sS "https://esi.evetech.net/meta/openapi.json" -o openapi.json
+# Pin the schema to a specific ESI compatibility date. This MUST match the
+# `x-compatibility-date` header sent at runtime in src/esi/cached.rs — otherwise ESI
+# serves responses shaped differently than the generated types expect. Available dates:
+# https://esi.evetech.net/meta/compatibility-dates
+COMPATIBILITY_DATE="2026-06-09"
 
-echo "Generating types..."
-oas3-gen generate types -i openapi.json -o types.rs --exclude get_meta_changelog
+echo "Downloading ESI OpenAPI schema ($COMPATIBILITY_DATE)..."
+curl -sS -H "x-compatibility-date: $COMPATIBILITY_DATE" "https://esi.evetech.net/meta/openapi.json" -o openapi.json
 
-echo "Generating client..."
-oas3-gen generate client -i openapi.json -o client.rs --exclude get_meta_changelog
+# client-mod emits a self-contained module (generated/{mod,client,types}.rs) with the
+# `use super::types::*` import and the `mod`/`pub use` wiring generated for us — no
+# manual file combining. --no-ordered-collections: emit Vec/HashMap instead of
+# indexmap::IndexSet/IndexMap (ESI deserialization does not depend on key/element order,
+# and IndexSet pulls in an extra dep plus an oas3-gen bug where set-element structs miss
+# Eq/Hash derives).
+echo "Generating ESI client module..."
+rm -rf "$GEN_DIR"
+oas3-gen generate client-mod -i openapi.json -o "$GEN_DIR" --exclude get_meta_changelog --no-ordered-collections
 
-echo "Adding types import to client.rs..."
-perl -pi -e 's/^use validator::Validate;$/use validator::Validate;\nuse super::types::*;/' client.rs
+# Work around oas3-gen 0.26.1 bug: x_compatibility_date is a required (non-Option)
+# NaiveDate header, but the generated HeaderMap conversion wraps it in `if let Some(..)`.
+echo "Fixing x_compatibility_date header generation..."
+perl -0pi -e 's/if let Some\(value\) = &headers\.x_compatibility_date \{/\{ let value = &headers.x_compatibility_date;/g' "$GEN_DIR/types.rs" "$GEN_DIR/client.rs"
 
-echo "Suppressing unused code warnings..."
-perl -pi -e '$_ = "#![allow(dead_code)]\n" . $_ if $. == 1' types.rs
-perl -pi -e '$_ = "#![allow(dead_code)]\n" . $_ if $. == 1' client.rs
+# The generated mod.rs allows several clippy lints but not every style lint the code
+# trips (needless_return, needless_question_mark, ...). A module-level allow propagates
+# to the child modules, so one blanket allow on this never-hand-edited module makes
+# `clippy -D warnings` pass.
+echo "Suppressing clippy warnings on generated code..."
+perl -pi -e '$_ = "#![allow(clippy::all)]\n" . $_ if $. == 1' "$GEN_DIR/mod.rs"
 
-echo "Done! Generated types.rs and client.rs in $ESI_DIR"
-
+echo "Done! Generated ESI module in $GEN_DIR"

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -3073,9 +3073,8 @@ dependencies = [
 
 [[package]]
 name = "oas3-gen-support"
-version = "0.26.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "639ee7295c66ace90f674d51f5b23ec6c18ea53acf23b029831d05ec2b00b639"
+version = "0.26.2"
+source = "git+https://github.com/snipereagle1/oas3-gen?branch=fix%2F92-required-header-default#6ab3421ee39be7700dc9327ac2b67fa9691630a7"
 dependencies = [
  "better_default",
  "bon",
@@ -3083,7 +3082,7 @@ dependencies = [
  "eventsource-stream",
  "futures-core",
  "http",
- "quick-xml 0.40.1",
+ "quick-xml 0.38.4",
  "reqwest",
  "serde",
  "serde_json",
@@ -3917,6 +3916,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b66c2058c55a409d601666cffe35f04333cf1013010882cec174a7467cd4e21c"
 dependencies = [
  "memchr",
+ "serde",
 ]
 
 [[package]]
@@ -3926,7 +3926,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2474bd2e5029e7ccb6abb2ba48cf2383a333851dedf495901544281590c7da7f"
 dependencies = [
  "memchr",
- "serde",
 ]
 
 [[package]]

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -259,6 +259,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
+name = "aws-lc-rs"
+version = "1.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ec2f1fc3ec205783a5da9a7e6c1509cc69dedf09a1949e412c1e18469326d00"
+dependencies = [
+ "aws-lc-sys",
+ "zeroize",
+]
+
+[[package]]
+name = "aws-lc-sys"
+version = "0.41.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a2f9779ce85b93ab6170dd940ad0169b5766ff848247aff13bb788b832fe3f4"
+dependencies = [
+ "cc",
+ "cmake",
+ "dunce",
+ "fs_extra",
+]
+
+[[package]]
 name = "axum"
 version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -404,6 +426,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "bon"
+version = "3.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a602c73c7b0148ec6d12af6fd5cc7a46e2eacc8878271a999abac56eed12f561"
+dependencies = [
+ "bon-macros",
+ "rustversion",
+]
+
+[[package]]
+name = "bon-macros"
+version = "3.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6dee98b0db6a962de883bf5d20362dee4d7ca0d12fe39a7c6c73c844e1cd7c1f"
+dependencies = [
+ "darling 0.23.0",
+ "ident_case",
+ "prettyplease",
+ "proc-macro2",
+ "quote",
+ "rustversion",
+ "syn 2.0.114",
+]
+
+[[package]]
 name = "brotli"
 version = "8.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -422,6 +469,15 @@ checksum = "874bb8112abecc98cbd6d81ea4fa7e94fb9449648c93cc89aa40c81c24d7de03"
 dependencies = [
  "alloc-no-stdlib",
  "alloc-stdlib",
+]
+
+[[package]]
+name = "bs58"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf88ba1141d185c399bee5288d850d63b8369520c1eafc32a0430b5b6c287bf4"
+dependencies = [
+ "tinyvec",
 ]
 
 [[package]]
@@ -531,6 +587,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "755d2fce177175ffca841e9a06afdb2c4ab0f593d53b4dee48147dfaade85932"
 dependencies = [
  "find-msvc-tools",
+ "jobserver",
+ "libc",
  "shlex",
 ]
 
@@ -568,6 +626,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
+name = "cfg_aliases"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
+
+[[package]]
 name = "chacha20"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -599,6 +663,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bde03770d3df201d4fb868f2c9c59e66a3e4e2bd06692a0fe701e7103c7e84d4"
 dependencies = [
  "error-code",
+]
+
+[[package]]
+name = "cmake"
+version = "0.1.58"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0f78a02292a74a88ac736019ab962ece0bc380e3f977bf72e376c5d78ff0678"
+dependencies = [
+ "cc",
 ]
 
 [[package]]
@@ -657,15 +730,6 @@ name = "convert_case"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6245d59a3e82a7fc217c5828a6692dbc6dfb63a0c8c90495621f7b9d79704a0e"
-
-[[package]]
-name = "convert_case"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "633458d4ef8c78b72454de2d54fd6ab2e60f9e02be22f3c6104cdc8a4e0fceb9"
-dependencies = [
- "unicode-segmentation",
-]
 
 [[package]]
 name = "cookie"
@@ -895,12 +959,12 @@ dependencies = [
 
 [[package]]
 name = "darling"
-version = "0.21.3"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9cdf337090841a411e2a7f3deb9187445851f91b309c0c0a29e05f74a00a48c0"
+checksum = "25ae13da2f202d56bd7f91c25fba009e7717a1e4a1cc98a76d844b65ae912e9d"
 dependencies = [
- "darling_core 0.21.3",
- "darling_macro 0.21.3",
+ "darling_core 0.23.0",
+ "darling_macro 0.23.0",
 ]
 
 [[package]]
@@ -919,11 +983,10 @@ dependencies = [
 
 [[package]]
 name = "darling_core"
-version = "0.21.3"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1247195ecd7e3c85f83c8d2a366e4210d588e802133e1e355180a9870b517ea4"
+checksum = "9865a50f7c335f53564bb694ef660825eb8610e0a53d3e11bf1b0d3df31e03b0"
 dependencies = [
- "fnv",
  "ident_case",
  "proc-macro2",
  "quote",
@@ -944,11 +1007,11 @@ dependencies = [
 
 [[package]]
 name = "darling_macro"
-version = "0.21.3"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d38308df82d1080de0afee5d069fa14b0326a88c14f15c5ccda35b4a6c414c81"
+checksum = "ac3984ec7bd6cfa798e62b4a642426a5be0e68f9401cfc2a01e3fa9ea2fcdb8d"
 dependencies = [
- "darling_core 0.21.3",
+ "darling_core 0.23.0",
  "quote",
  "syn 2.0.114",
 ]
@@ -966,11 +1029,10 @@ dependencies = [
 
 [[package]]
 name = "deranged"
-version = "0.5.5"
+version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ececcb659e7ba858fb4f10388c250a7252eb0a27373f1a72b8748afdd248e587"
+checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
 dependencies = [
- "powerfmt",
  "serde_core",
 ]
 
@@ -991,7 +1053,7 @@ version = "0.99.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6edb4b64a43d977b8e99788fe3a04d483834fba1215a7e02caa415b626497f7f"
 dependencies = [
- "convert_case 0.4.0",
+ "convert_case",
  "proc-macro2",
  "quote",
  "rustc_version",
@@ -1013,12 +1075,10 @@ version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "799a97264921d8623a957f6c3b9011f3b5492f557bbb7a5a19b7fa6d06ba8dcb"
 dependencies = [
- "convert_case 0.10.0",
  "proc-macro2",
  "quote",
  "rustc_version",
  "syn 2.0.114",
- "unicode-xid",
 ]
 
 [[package]]
@@ -1327,6 +1387,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "eventsource-stream"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "74fef4569247a5f429d9156b9d0a2599914385dd189c539334c625d8099d90ab"
+dependencies = [
+ "futures-core",
+ "nom 7.1.3",
+ "pin-project-lite",
+]
+
+[[package]]
 name = "fastrand"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1484,6 +1555,12 @@ checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
 dependencies = [
  "percent-encoding",
 ]
+
+[[package]]
+name = "fs_extra"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
 
 [[package]]
 name = "futf"
@@ -1737,8 +1814,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "wasi 0.11.1+wasi-snapshot-preview1",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -1748,9 +1827,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "r-efi 5.3.0",
  "wasip2",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -1925,7 +2006,7 @@ dependencies = [
  "futures-core",
  "futures-sink",
  "http",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "slab",
  "tokio",
  "tokio-util",
@@ -1974,6 +2055,12 @@ dependencies = [
  "equivalent",
  "foldhash 0.2.0",
 ]
+
+[[package]]
+name = "hashbrown"
+version = "0.17.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
 
 [[package]]
 name = "hashlink"
@@ -2137,22 +2224,6 @@ dependencies = [
  "rustls-pki-types",
  "tokio",
  "tokio-rustls",
- "tower-service",
-]
-
-[[package]]
-name = "hyper-tls"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70206fc6890eaca9fde8a0bf71caa2ddfc9fe045ac9e5c70df101a7dbde866e0"
-dependencies = [
- "bytes",
- "http-body-util",
- "hyper",
- "hyper-util",
- "native-tls",
- "tokio",
- "tokio-native-tls",
  "tower-service",
 ]
 
@@ -2351,12 +2422,12 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.13.0"
+version = "2.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7714e70437a7dc3ac8eb7e6f8df75fd8eb422675fc7678aff7364301092b1017"
+checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
 dependencies = [
  "equivalent",
- "hashbrown 0.16.1",
+ "hashbrown 0.17.1",
  "serde",
  "serde_core",
 ]
@@ -2496,6 +2567,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "jobserver"
+version = "0.1.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9afb3de4395d6b3e67a780b6de64b51c978ecf11cb9a462c66be7d4ca9039d33"
+dependencies = [
+ "getrandom 0.3.4",
+ "libc",
+]
+
+[[package]]
 name = "js-sys"
 version = "0.3.85"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2563,7 +2644,7 @@ checksum = "02cb977175687f33fa4afa0c95c112b987ea1443e5a51c8f8ff27dc618270cc2"
 dependencies = [
  "cssparser 0.29.6",
  "html5ever 0.29.1",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "selectors 0.24.0",
 ]
 
@@ -2672,6 +2753,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "953f07c43838f8e6f9758cab68bf5bed85465e7587ebe0b823f1bcd81978ad3a"
 
 [[package]]
+name = "lru-slab"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
+
+[[package]]
 name = "mac"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2777,6 +2864,12 @@ dependencies = [
  "mime",
  "unicase",
 ]
+
+[[package]]
+name = "minimal-lexical"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
 name = "minisign-verify"
@@ -2891,6 +2984,16 @@ checksum = "72ef4a56884ca558e5ddb05a1d1e7e1bfd9a68d9ed024c21704cc98872dae1bb"
 
 [[package]]
 name = "nom"
+version = "7.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
+dependencies = [
+ "memchr",
+ "minimal-lexical",
+]
+
+[[package]]
+name = "nom"
 version = "8.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df9761775871bdef83bee530e60050f7e54b1105350d6884eb0fb4f46c2f9405"
@@ -2924,9 +3027,9 @@ dependencies = [
 
 [[package]]
 name = "num-conv"
-version = "0.1.0"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "51d515d32fb182ee37cda2ccdcb92950d6a3c2893aa280e540671c2cd0f3b1d9"
+checksum = "521739c6d2bac4aa25192232afe6841231376b2b26d4d9fae5ecf8ca5772e441"
 
 [[package]]
 name = "num-integer"
@@ -2969,49 +3072,24 @@ dependencies = [
 ]
 
 [[package]]
-name = "oas3"
-version = "0.20.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "16f67c885c7b19aaf652e84102035258ecb4e0425a4f71037e187798e367bd87"
-dependencies = [
- "derive_more 2.1.1",
- "http",
- "log",
- "once_cell",
- "regex",
- "semver",
- "serde",
- "serde_json",
- "serde_yaml",
- "url",
-]
-
-[[package]]
 name = "oas3-gen-support"
-version = "0.22.5"
+version = "0.26.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af44280e69466593d3bfc26f033ededc7bddab7318fa902a970c9958380fcb67"
+checksum = "639ee7295c66ace90f674d51f5b23ec6c18ea53acf23b029831d05ec2b00b639"
 dependencies = [
- "anyhow",
  "better_default",
+ "bon",
  "chrono",
+ "eventsource-stream",
+ "futures-core",
  "http",
- "indexmap 2.13.0",
- "oas3",
- "percent-encoding",
- "prettyplease",
- "proc-macro2",
- "quote",
- "regex",
- "reqwest 0.12.28",
+ "quick-xml 0.40.1",
+ "reqwest",
  "serde",
  "serde_json",
  "serde_path_to_error",
- "serde_plain",
  "serde_with",
- "syn 2.0.114",
  "thiserror 2.0.18",
- "uuid",
  "validator",
 ]
 
@@ -3426,7 +3504,7 @@ checksum = "8701b58ea97060d5e5b155d383a69952a60943f0e6dfe30b04c287beb0b27455"
 dependencies = [
  "fixedbitset",
  "hashbrown 0.15.5",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
 ]
 
 [[package]]
@@ -3632,7 +3710,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "740ebea15c5d1428f910cd1a5f52cebf8d25006245ed8ade92702f4943d91e07"
 dependencies = [
  "base64 0.22.1",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "quick-xml 0.38.4",
  "serde",
  "time",
@@ -3848,6 +3926,63 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2474bd2e5029e7ccb6abb2ba48cf2383a333851dedf495901544281590c7da7f"
 dependencies = [
  "memchr",
+ "serde",
+]
+
+[[package]]
+name = "quinn"
+version = "0.11.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c1a41e437b6bbd489372cd4971de128e85c855f56c57f283d20ff016cf7c0a8"
+dependencies = [
+ "bytes",
+ "cfg_aliases",
+ "pin-project-lite",
+ "quinn-proto",
+ "quinn-udp",
+ "rustc-hash",
+ "rustls",
+ "socket2",
+ "thiserror 2.0.18",
+ "tokio",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-proto"
+version = "0.11.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fcb935c5bec503c2f0e306bdd3e58bb9029dcb14fa8d9ac76e3a5256ac0763e"
+dependencies = [
+ "aws-lc-rs",
+ "bytes",
+ "getrandom 0.3.4",
+ "lru-slab",
+ "rand 0.9.3",
+ "ring",
+ "rustc-hash",
+ "rustls",
+ "rustls-pki-types",
+ "slab",
+ "thiserror 2.0.18",
+ "tinyvec",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-udp"
+version = "0.5.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "addec6a0dcad8a8d96a771f815f0eaf55f9d1805756410b39f5fa81332574cbd"
+dependencies = [
+ "cfg_aliases",
+ "libc",
+ "once_cell",
+ "socket2",
+ "tracing",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -4084,9 +4219,9 @@ checksum = "7a2d987857b319362043e95f5353c0535c1f58eec5336fdfcf626430af7def58"
 
 [[package]]
 name = "reqwest"
-version = "0.12.28"
+version = "0.13.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
+checksum = "219c5811de6525e5416c7d5d53bb656d3afdbc6c5af816e0802bcfa42dbdc1c3"
 dependencies = [
  "base64 0.22.1",
  "bytes",
@@ -4099,58 +4234,20 @@ dependencies = [
  "http-body-util",
  "hyper",
  "hyper-rustls",
- "hyper-tls",
  "hyper-util",
  "js-sys",
  "log",
  "mime",
  "mime_guess",
- "native-tls",
  "percent-encoding",
  "pin-project-lite",
- "rustls-pki-types",
- "serde",
- "serde_json",
- "serde_urlencoded",
- "sync_wrapper",
- "tokio",
- "tokio-native-tls",
- "tokio-util",
- "tower",
- "tower-http",
- "tower-service",
- "url",
- "wasm-bindgen",
- "wasm-bindgen-futures",
- "wasm-streams 0.4.2",
- "web-sys",
-]
-
-[[package]]
-name = "reqwest"
-version = "0.13.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "219c5811de6525e5416c7d5d53bb656d3afdbc6c5af816e0802bcfa42dbdc1c3"
-dependencies = [
- "base64 0.22.1",
- "bytes",
- "futures-core",
- "futures-util",
- "http",
- "http-body",
- "http-body-util",
- "hyper",
- "hyper-rustls",
- "hyper-util",
- "js-sys",
- "log",
- "percent-encoding",
- "pin-project-lite",
+ "quinn",
  "rustls",
  "rustls-pki-types",
  "rustls-platform-verifier",
  "serde",
  "serde_json",
+ "serde_urlencoded",
  "sync_wrapper",
  "tokio",
  "tokio-rustls",
@@ -4161,7 +4258,7 @@ dependencies = [
  "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
- "wasm-streams 0.5.0",
+ "wasm-streams",
  "web-sys",
 ]
 
@@ -4247,6 +4344,7 @@ version = "0.23.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c665f33d38cea657d9614f766881e4d510e0eda4239891eea56b4cadcf01801b"
 dependencies = [
+ "aws-lc-rs",
  "once_cell",
  "ring",
  "rustls-pki-types",
@@ -4273,6 +4371,7 @@ version = "1.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be040f8b0a225e40375822a563fa9524378b9d63112f53e19ffff34df5d33fdd"
 dependencies = [
+ "web-time",
  "zeroize",
 ]
 
@@ -4309,6 +4408,7 @@ version = "0.103.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d7df23109aa6c1567d1c575b9952556388da57401e4ace1d15f79eedad0d8f53"
 dependencies = [
+ "aws-lc-rs",
  "ring",
  "rustls-pki-types",
  "untrusted",
@@ -4543,7 +4643,7 @@ version = "1.0.150"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e8014e44b4736ed0538adeecded0fce2a272f22dc9578a7eb6b2d9993c74cfb9"
 dependencies = [
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "itoa",
  "memchr",
  "serde",
@@ -4614,15 +4714,16 @@ dependencies = [
 
 [[package]]
 name = "serde_with"
-version = "3.16.1"
+version = "3.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fa237f2807440d238e0364a218270b98f767a00d3dada77b1c53ae88940e2e7"
+checksum = "76a5c54c7310e7b8b9577c286d7e399ddd876c3e12b3ed917a8aabc4b96e9e8c"
 dependencies = [
  "base64 0.22.1",
+ "bs58",
  "chrono",
  "hex",
  "indexmap 1.9.3",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "schemars 0.9.0",
  "schemars 1.2.0",
  "serde_core",
@@ -4633,27 +4734,14 @@ dependencies = [
 
 [[package]]
 name = "serde_with_macros"
-version = "3.16.1"
+version = "3.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52a8e3ca0ca629121f70ab50f95249e5a6f925cc0f6ffe8256c45b728875706c"
+checksum = "84d57bc0c8b9a17920c178daa6bb924850d54a9c97ab45194bb8c17ad66bb660"
 dependencies = [
- "darling 0.21.3",
+ "darling 0.23.0",
  "proc-macro2",
  "quote",
  "syn 2.0.114",
-]
-
-[[package]]
-name = "serde_yaml"
-version = "0.9.34+deprecated"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a8b1a1a2ebf674015cc02edccce75287f1a0130d394307b36743c2f5d504b47"
-dependencies = [
- "indexmap 2.13.0",
- "itoa",
- "ryu",
- "serde",
- "unsafe-libyaml",
 ]
 
 [[package]]
@@ -4820,10 +4908,11 @@ dependencies = [
  "oas3-gen-support",
  "quick-xml 0.40.1",
  "rand 0.10.1",
- "reqwest 0.12.28",
+ "reqwest",
  "serde",
  "serde_json",
  "serde_plain",
+ "serde_with",
  "sha2 0.11.0",
  "sqlx",
  "tauri",
@@ -4845,6 +4934,7 @@ dependencies = [
  "typeshare",
  "url",
  "urlencoding",
+ "uuid",
  "validator",
  "zip 8.6.0",
 ]
@@ -4963,7 +5053,7 @@ dependencies = [
  "futures-util",
  "hashbrown 0.16.1",
  "hashlink",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "log",
  "memchr",
  "native-tls",
@@ -5367,7 +5457,7 @@ dependencies = [
  "percent-encoding",
  "plist",
  "raw-window-handle",
- "reqwest 0.13.4",
+ "reqwest",
  "serde",
  "serde_json",
  "serde_repr",
@@ -5636,7 +5726,7 @@ dependencies = [
  "minisign-verify",
  "osakit",
  "percent-encoding",
- "reqwest 0.13.4",
+ "reqwest",
  "rustls",
  "semver",
  "serde",
@@ -5857,12 +5947,11 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.45"
+version = "0.3.51"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9e442fc33d7fdb45aa9bfeb312c095964abdf596f7567261062b2a7107aaabd"
+checksum = "85c17d80feb7334b40c484e45ed1a5273dfd8bfda537c3be2e74a06a6686f327"
 dependencies = [
  "deranged",
- "itoa",
  "num-conv",
  "powerfmt",
  "serde_core",
@@ -5872,15 +5961,15 @@ dependencies = [
 
 [[package]]
 name = "time-core"
-version = "0.1.7"
+version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b36ee98fd31ec7426d599183e8fe26932a8dc1fb76ddb6214d05493377d34ca"
+checksum = "9e1c906769ad99c88eaa54e728060edef082f8e358ff32030cb7c7d315e81109"
 
 [[package]]
 name = "time-macros"
-version = "0.2.25"
+version = "0.2.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "71e552d1249bf61ac2a52db88179fd0673def1e1ad8243a00d9ec9ed71fee3dd"
+checksum = "dcef1a61bdb119096e153208ec5cbec23944ce8bca13be5c7f60c634f7403935"
 dependencies = [
  "num-conv",
  "time-core",
@@ -5949,16 +6038,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "tokio-native-tls"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbae76ab933c85776efabc971569dd6119c580d8f5d448769dec1764bf796ef2"
-dependencies = [
- "native-tls",
- "tokio",
-]
-
-[[package]]
 name = "tokio-rustls"
 version = "0.26.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6010,7 +6089,7 @@ version = "0.9.11+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f3afc9a848309fe1aaffaed6e1546a7a14de1f935dc9d89d32afd9a44bab7c46"
 dependencies = [
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "serde_core",
  "serde_spanned 1.1.1",
  "toml_datetime 0.7.5+spec-1.1.0",
@@ -6025,7 +6104,7 @@ version = "1.1.2+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "81f3d15e84cbcd896376e6730314d59fb5a87f31e4b038454184435cd57defee"
 dependencies = [
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "serde_core",
  "serde_spanned 1.1.1",
  "toml_datetime 1.1.1+spec-1.1.0",
@@ -6067,7 +6146,7 @@ version = "0.19.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b5bb770da30e5cbfde35a2d7b9b8a2c4b8ef89548a7a6aeab5c9a576e3e7421"
 dependencies = [
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "toml_datetime 0.6.3",
  "winnow 0.5.40",
 ]
@@ -6078,7 +6157,7 @@ version = "0.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "396e4d48bbb2b7554c944bde63101b5ae446cff6ec4a24227428f15eb72ef338"
 dependencies = [
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "serde",
  "serde_spanned 0.6.9",
  "toml_datetime 0.6.3",
@@ -6091,7 +6170,7 @@ version = "0.23.10+spec-1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "84c8b9f757e028cee9fa244aea147aab2a9ec09d5325a9b01e0a49730c2b5269"
 dependencies = [
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "toml_datetime 0.7.5+spec-1.1.0",
  "toml_parser",
  "winnow 0.7.14",
@@ -6219,7 +6298,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8765b90061cba6c22b5831f675da109ae5561588290f9fa2317adab2714d5a6"
 dependencies = [
  "memchr",
- "nom",
+ "nom 8.0.0",
  "petgraph",
 ]
 
@@ -6361,18 +6440,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f6ccf251212114b54433ec949fd6a7841275f9ada20dddd2f29e9ceea4501493"
 
 [[package]]
-name = "unicode-xid"
-version = "0.2.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
-
-[[package]]
-name = "unsafe-libyaml"
-version = "0.2.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "673aac59facbab8a9007c7f6108d11f63b603f7cabff99fabf650fea5c32b861"
-
-[[package]]
 name = "untrusted"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6423,11 +6490,11 @@ checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
 
 [[package]]
 name = "uuid"
-version = "1.19.0"
+version = "1.23.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2e054861b4bd027cd373e18e8d8d8e6548085000e41290d95ce0c373a654b4a"
+checksum = "bf80a72845275afea99e7f2b434723d3bc7e38470fcd1c7ed39a599c73319a53"
 dependencies = [
- "getrandom 0.3.4",
+ "getrandom 0.4.3",
  "js-sys",
  "serde_core",
  "wasm-bindgen",
@@ -6602,19 +6669,6 @@ dependencies = [
 
 [[package]]
 name = "wasm-streams"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15053d8d85c7eccdbefef60f06769760a563c7f0a9d6902a13d35c7800b0ad65"
-dependencies = [
- "futures-util",
- "js-sys",
- "wasm-bindgen",
- "wasm-bindgen-futures",
- "web-sys",
-]
-
-[[package]]
-name = "wasm-streams"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d1ec4f6517c9e11ae630e200b2b65d193279042e28edd4a2cda233e46670bbb"
@@ -6701,6 +6755,16 @@ name = "web-sys"
 version = "0.3.85"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "312e32e551d92129218ea9a2452120f4aabc03529ef03e4d0d82fb2780608598"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "web-time"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -7606,7 +7670,7 @@ checksum = "caa8cd6af31c3b31c6631b8f483848b91589021b28fffe50adada48d4f4d2ed1"
 dependencies = [
  "arbitrary",
  "crc32fast",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "memchr",
 ]
 
@@ -7618,7 +7682,7 @@ checksum = "2d04a6b5381502aa6087c94c669499eb1602eb9c5e8198e534de571f7154809b"
 dependencies = [
  "crc32fast",
  "flate2",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "memchr",
  "typed-path",
  "zopfli",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -42,7 +42,7 @@ typeshare = "1.0.5"
 sqlx = { version = "0.9.0", features = ["runtime-tokio", "tls-native-tls", "sqlite"] }
 anyhow = "1.0.102"
 async-trait = "0.1.89"
-reqwest = { version = "0.12", features = ["json", "multipart", "stream"] }
+reqwest = { version = "0.13", features = ["json", "multipart", "stream", "query", "form"] }
 futures-util = "0.3.32"
 base64 = "0.22.1"
 sha2 = "0.11.0"
@@ -57,8 +57,10 @@ tower = "0.5.3"
 tower-http = { version = "0.6.11", features = ["cors"] }
 validator = { version = "0.20.0", features = ["derive"] }
 http = "1.4.2"
-oas3-gen-support = "0.22"
+oas3-gen-support = "0.26"
 serde_plain = "1.0.2"
+serde_with = "3.21"
+uuid = { version = "1.23", features = ["serde"] }
 zip = { version = "8.6.0", default-features = false, features = ["deflate"] }
 quick-xml = "0.40"
 dotenvy = "0.15.7"

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -57,7 +57,7 @@ tower = "0.5.3"
 tower-http = { version = "0.6.11", features = ["cors"] }
 validator = { version = "0.20.0", features = ["derive"] }
 http = "1.4.2"
-oas3-gen-support = "0.26"
+oas3-gen-support = { git = "https://github.com/snipereagle1/oas3-gen", branch = "fix/92-required-header-default" }
 serde_plain = "1.0.2"
 serde_with = "3.21"
 uuid = { version = "1.23", features = ["serde"] }

--- a/src-tauri/src/clone_sync.rs
+++ b/src-tauri/src/clone_sync.rs
@@ -107,32 +107,23 @@ pub async fn sync_character_clones_to_db(
     let mut matched_clone_location_update: Option<(String, i64)> = None;
 
     for jump_clone in &clones_data.jump_clones {
-        if let Some(obj) = jump_clone.as_object() {
-            let clone_id = obj.get("jump_clone_id").and_then(|v| v.as_i64());
-            let location_id = obj.get("location_id").and_then(|v| v.as_i64()).unwrap_or(0);
-            let location_type_str = obj
-                .get("location_type")
-                .and_then(|v| v.as_str())
-                .unwrap_or("station");
-            let implants = obj
-                .get("implants")
-                .and_then(|v| v.as_array())
-                .map(|arr| arr.iter().filter_map(|v| v.as_i64()).collect::<Vec<_>>())
-                .unwrap_or_default();
+        let location_type_str = match jump_clone.location_type {
+            esi::CharactersCharacterIdClonesGetHomeLocationLocationType::Station => "station",
+            esi::CharactersCharacterIdClonesGetHomeLocationLocationType::Structure => "structure",
+        };
+        let location_id = jump_clone.location_id;
 
-            let _ =
-                resolve_clone_location(pool, client, location_type_str, location_id, rate_limits)
-                    .await;
+        let _ =
+            resolve_clone_location(pool, client, location_type_str, location_id, rate_limits).await;
 
-            clones_to_store.push((
-                clone_id,
-                None,
-                location_type_str.to_string(),
-                location_id,
-                false,
-                implants,
-            ));
-        }
+        clones_to_store.push((
+            Some(jump_clone.jump_clone_id),
+            None,
+            location_type_str.to_string(),
+            location_id,
+            false,
+            jump_clone.implants.clone(),
+        ));
     }
 
     let mut current_implants_sorted = current_implants.clone();

--- a/src-tauri/src/esi/cached.rs
+++ b/src-tauri/src/esi/cached.rs
@@ -83,7 +83,10 @@ pub async fn fetch_cached<T: serde::de::DeserializeOwned>(
 
     let mut req_builder = client.get(url);
     req_builder = req_builder.header(ACCEPT_LANGUAGE, "en");
-    req_builder = req_builder.header("x-compatibility-date", "2020-01-01");
+    // Must match the compatibility date the ESI schema is generated against in
+    // scripts/generate-esi.sh — otherwise ESI returns responses shaped differently
+    // than the generated types expect.
+    req_builder = req_builder.header("x-compatibility-date", "2026-06-09");
     req_builder = req_builder.header("x-tenant", "tranquility");
 
     // If we have an ETag (even if expired), use it for conditional request

--- a/src-tauri/src/esi/mod.rs
+++ b/src-tauri/src/esi/mod.rs
@@ -1,6 +1,7 @@
 pub mod cached;
 pub mod scopes;
 #[rustfmt::skip]
+#[allow(clippy::all)]
 mod generated;
 
 pub use cached::{fetch_cached, RateLimitInfo, RateLimitStore};

--- a/src-tauri/src/esi/mod.rs
+++ b/src-tauri/src/esi/mod.rs
@@ -1,11 +1,8 @@
 pub mod cached;
 pub mod scopes;
 #[rustfmt::skip]
-pub mod client;
-#[rustfmt::skip]
-pub mod types;
+mod generated;
 
 pub use cached::{fetch_cached, RateLimitInfo, RateLimitStore};
-pub use client::BASE_URL;
+pub use generated::*;
 pub use scopes::{EsiScope, BASE_SCOPES};
-pub use types::*;


### PR DESCRIPTION
## Summary

Modernizes the generated ESI client toolchain:

- **reqwest 0.12 → 0.13** (with `query` + `form` features, now gated in 0.13)
- **oas3-gen 0.24 → 0.26**, switching from single-file `client` output to `client-mod` — emits a self-contained `generated/{mod,client,types}.rs` module, eliminating the manual file-combining step in `generate-esi.sh`
- **Fork pin**: `oas3-gen-support` points at `snipereagle1/oas3-gen#fix/92-required-header-default` (0.26.2) to pick up the `x_compatibility_date` required-header fix (upstream PR eklipse2k8/oas3-gen#93); the CLI install + CI cache keys (`oas3-gen-fork-fix-92`) match. Revert all three to a published version once the fix lands upstream.
- **`--no-ordered-collections`**: generated code emits `Vec`/`HashMap` instead of `indexmap` types (ESI deserialization is order-independent; also avoids an oas3-gen bug where `uniqueItems` set-element structs miss `Eq`/`Hash` derives)
- **Clippy suppression moved out of the script**: `#[allow(clippy::all)]` now sits on the `mod generated;` declaration in `src/esi/mod.rs`, so the script no longer patches generated files at all

## Coupled changes

- CI workflows (`ci.yml`, `release.yml`, `build-adhoc.yml`) install the fork CLI and bump the cache key
- `clone_sync.rs` / `cached.rs` adjusted to the new generated API surface

## Testing

- `pnpm verify` green (lint, clippy `-D warnings`, typecheck, format, 192 frontend + 74 Rust tests)
- ESI client regenerated from the 2026-06-09 compatibility-date schema (1504 types, 217 methods)